### PR TITLE
게시글 및 게시판 리스트 조회 시 댓글 개수 표시 기능 추가

### DIFF
--- a/src/interfaces/board/boardInDB.ts
+++ b/src/interfaces/board/boardInDB.ts
@@ -12,7 +12,7 @@ export interface BoardInDBDto {
   updated_at: Date;
   deleted_at: Date | null;
   board_order: number;
-  board_comment: number;
+  board_comment: number | string;
   user_nickname: string;
   tags: string[];
   isLike: boolean;

--- a/src/services/board/board.ts
+++ b/src/services/board/board.ts
@@ -7,8 +7,9 @@ import { SingleNotificationResponse } from '../../interfaces/response';
 export class BoardService {
   static getBoard = async (boardIdInfoDto: BoardIdInfoDto) => {
     try {
-      const [data] = await db.query(
-        `SELECT Board.*, User.user_nickname , User.user_email
+      let [data] = await db.query(
+        `SELECT Board.*, User.user_nickname , User.user_email,
+      (SELECT COUNT(*) FROM Comment WHERE Comment.board_id = Board.board_id AND Comment.deleted_at IS NULL) AS board_comment
        FROM Board 
        JOIN User ON Board.user_id = User.user_id
        WHERE Board.board_id = ? AND Board.deleted_at IS NULL 
@@ -16,6 +17,11 @@ export class BoardService {
         [boardIdInfoDto.boardId]
       );
       if (!data) throw new Error('존재하지 않는 게시글입니다.');
+
+      data = {
+        ...data,
+        board_comment: parseInt(data.board_comment)
+      };
 
       if (!data.category_id) data.category_name = '기본 카테고리';
 

--- a/src/services/board/board.ts
+++ b/src/services/board/board.ts
@@ -3,6 +3,7 @@ import { ensureError } from '../../errors/ensureError';
 import { BoardIdInfoDto } from '../../interfaces/board/IdInfo';
 import { redis } from '../../loaders/redis';
 import { SingleNotificationResponse } from '../../interfaces/response';
+import { parseFieldToNumber } from '../../utils/parseFieldToNumber';
 
 export class BoardService {
   static getBoard = async (boardIdInfoDto: BoardIdInfoDto) => {
@@ -18,10 +19,7 @@ export class BoardService {
       );
       if (!data) throw new Error('존재하지 않는 게시글입니다.');
 
-      data = {
-        ...data,
-        board_comment: parseInt(data.board_comment)
-      };
+      data = parseFieldToNumber(data, 'board_comment');
 
       if (!data.category_id) data.category_name = '기본 카테고리';
 

--- a/src/services/board/boardList.ts
+++ b/src/services/board/boardList.ts
@@ -9,6 +9,7 @@ import {
 } from '../../interfaces/board/listDto';
 import { BoardInDBDto } from '../../interfaces/board/boardInDB';
 import { ListResponse, UserListResponse } from '../../interfaces/response';
+import { parseFieldToNumber } from '../../utils/parseFieldToNumber';
 
 export class BoardListService {
   static getList = async (listDto: ListDto): Promise<ListResponse> => {
@@ -266,12 +267,7 @@ export class BoardListService {
       params
     );
 
-    data = data.map((row: BoardInDBDto) => {
-      return {
-        ...row,
-        board_comment: parseInt(row.board_comment as string)
-      };
-    });
+    data = parseFieldToNumber(data, 'board_comment');
 
     // 2. 캐시된 좋아요/ 조회수 반영
     data = await this._reflectCashed(data);
@@ -350,12 +346,7 @@ export class BoardListService {
       params
     );
 
-    data = data.map((row: any) => {
-      return {
-        ...row,
-        board_comment: parseInt(row.board_comment)
-      };
-    });
+    data = parseFieldToNumber(data, 'board_comment');
 
     //커서가 있고, 이전 페이지를 조회하는 경우
     if (options.cursor && options.isBefore === true) data = data.reverse();

--- a/src/services/board/boardList.ts
+++ b/src/services/board/boardList.ts
@@ -257,13 +257,21 @@ export class BoardListService {
   ): Promise<BoardInDBDto[]> {
     // 1. 전체 게시글 반환
     let data = await db.query(
-      `SELECT DISTINCT Board.*, User.user_nickname, User.user_email, Board_Category.category_name 
+      `SELECT DISTINCT Board.*, User.user_nickname, User.user_email, Board_Category.category_name, 
+      (SELECT COUNT(*) FROM Comment WHERE Comment.board_id = Board.board_id AND Comment.deleted_at IS NULL) as board_comment 
         FROM Board 
         LEFT JOIN User ON Board.user_id = User.user_id
         LEFT JOIN Board_Category ON Board.category_id = Board_Category.category_id` +
         query,
       params
     );
+
+    data = data.map((row: BoardInDBDto) => {
+      return {
+        ...row,
+        board_comment: parseInt(row.board_comment as string)
+      };
+    });
 
     // 2. 캐시된 좋아요/ 조회수 반영
     data = await this._reflectCashed(data);
@@ -333,13 +341,21 @@ export class BoardListService {
     }
 
     let data = await db.query(
-      `SELECT DISTINCT Board.*, User.user_nickname, User.user_email, Board_Category.category_name 
+      `SELECT DISTINCT Board.*, User.user_nickname, User.user_email, Board_Category.category_name, 
+      (SELECT COUNT(*) FROM Comment WHERE Comment.board_id = Board.board_id AND Comment.deleted_at IS NULL) as board_comment 
         FROM Board 
         LEFT JOIN User ON Board.user_id = User.user_id
         LEFT JOIN Board_Category ON Board.category_id = Board_Category.category_id` +
         query,
       params
     );
+
+    data = data.map((row: any) => {
+      return {
+        ...row,
+        board_comment: parseInt(row.board_comment)
+      };
+    });
 
     //커서가 있고, 이전 페이지를 조회하는 경우
     if (options.cursor && options.isBefore === true) data = data.reverse();

--- a/src/utils/parseFieldToNumber.ts
+++ b/src/utils/parseFieldToNumber.ts
@@ -1,0 +1,16 @@
+// 배열 또는 객체 내 특정 필드를 숫자로 변환
+export function parseFieldToNumber<T extends Record<string, any>>(
+  data: T | T[],
+  fieldName: keyof T
+): T | T[] {
+  if (Array.isArray(data)) {
+    return data.map((row) => ({
+      ...row,
+      [fieldName]: parseInt(row[fieldName] as string, 10)
+    }));
+  }
+  return {
+    ...data,
+    [fieldName]: parseInt(data[fieldName] as string, 10)
+  };
+}


### PR DESCRIPTION
## 🌎 PR 요약

특정 게시글을 조회하거나 게시판 리스트를 조회할 때, 각 게시글의 댓글 개수를 표시하는 기능을 추가했습니다.

## 🔍 PR 유형

- [x] ✨ 새로운 기능 (Feature)
- [x] ♻️ 리팩토링 (기능 변경 없음, API 변경 없음)

## 📝 작업 내용

- [x] 게시글에 속한 댓글의 개수를 데이터베이스에서 조회하여, 삭제되지 않은 댓글만을 집계해 표시하는 로직을 추가
- [x] 기존의 parseInt를 사용하는 로직을 제거하고, 배열 또는 객체 내 특정 필드를 숫자로 변환하는 `parseFieldToNumber` 유틸리티 함수로 통합하여 코드 중복을 줄임

## 📍 참고 사항

필드 변환 로직은 유틸리티 함수로 통합해 향후 유지보수 및 성능 최적화를 도모했습니다.

## #️⃣ 연관된 이슈
