### PR TITLE
알림 로직 분리 및 게시물 좋아요/대댓글 알림 수정

### DIFF
--- a/src/interfaces/notification.ts
+++ b/src/interfaces/notification.ts
@@ -32,3 +32,8 @@ export interface NotificationListDto {
   isBefore: boolean;
   sort: string;
 }
+
+export interface RetryFailedUsersResult {
+  dbSaveFails: string[];
+  notifyFails: string[];
+}

--- a/src/interfaces/notification.ts
+++ b/src/interfaces/notification.ts
@@ -11,9 +11,11 @@ export interface NotificationDto {
   };
   location?: {
     boardId?: string;
+    parentCommentId?: string;
     commentId?: string;
     boardTitle?: string;
     commentContent?: string;
+    boardWriterNickname?: string;
   };
   id?: string;
 }

--- a/src/routes/board.ts
+++ b/src/routes/board.ts
@@ -15,7 +15,7 @@ import {
 } from '../interfaces/board/listDto';
 import { upload } from '../middleware/multer';
 import { checkWriter } from '../middleware/checkWriter';
-import { saveNotificationService } from '../services/Notification/saveNotifications';
+import { SaveNotificationService } from '../services/Notification/saveNotifications';
 import {
   ListResponse,
   SingleNotificationResponse,
@@ -305,7 +305,7 @@ boardRouter.post(
 
       if (result.result === true && result.notifications) {
         const notified =
-          await saveNotificationService.createMultiUserNotification(
+          await SaveNotificationService.createMultiUserNotification(
             result.notifications
           );
         return res.status(notified.result ? 200 : 500).send(notified);
@@ -466,7 +466,7 @@ boardRouter.post(
 
       if (result.result === true && result.notifications) {
         const notified =
-          await saveNotificationService.createSingleUserNotification(
+          await SaveNotificationService.createSingleUserNotification(
             result.notifications
           );
         return res.status(notified.result ? 200 : 500).send(notified);

--- a/src/routes/comment.ts
+++ b/src/routes/comment.ts
@@ -12,7 +12,7 @@ import {
   ParentCommentIdDto
 } from '../interfaces/comment';
 import { MultipleNotificationResponse } from '../interfaces/response';
-import { saveNotificationService } from '../services/Notification/saveNotifications';
+import { SaveNotificationService } from '../services/Notification/saveNotifications';
 import { CommentListService } from '../services/comment/commentList';
 
 export const commentRouter = Router();
@@ -58,7 +58,7 @@ commentRouter.post(
 
         if (result.notifications.replyToComment) {
           promises.push(
-            saveNotificationService.createSingleUserNotification(
+            SaveNotificationService.createSingleUserNotification(
               result.notifications.replyToComment
             )
           );
@@ -66,7 +66,7 @@ commentRouter.post(
 
         if (result.notifications.commentOnBoard) {
           promises.push(
-            saveNotificationService.createSingleUserNotification(
+            SaveNotificationService.createSingleUserNotification(
               result.notifications.commentOnBoard
             )
           );

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -20,7 +20,7 @@ import { FollowListDto } from '../interfaces/user/follow';
 import { LimitRequestDto } from '../interfaces/limitRequestDto';
 import { upload } from '../middleware/multer';
 import { jwtAuth } from '../middleware/passport-jwt-checker';
-import { saveNotificationService } from '../services/Notification/saveNotifications';
+import { SaveNotificationService } from '../services/Notification/saveNotifications';
 export const usersRouter = Router();
 
 // 특정 이메일/닉네임의 중복 여부 확인 (POST : /users/duplication)
@@ -198,7 +198,7 @@ usersRouter.post(
 
       if (result.result === true && result.notifications) {
         const notified =
-          await saveNotificationService.createSingleUserNotification(
+          await SaveNotificationService.createSingleUserNotification(
             result.notifications
           );
         return notified.result

--- a/src/services/Notification/notification.ts
+++ b/src/services/Notification/notification.ts
@@ -16,71 +16,9 @@ export class NotificationService {
       const pageSize = listDto.pageSize || 10;
       const totalPageCount = Math.ceil(totalCount / pageSize);
 
-      let query = `
-      SELECT 
-        Notifications.notification_id, 
-        Notifications.notification_recipient, 
-        Notifications.notification_type, 
-        Notifications.notification_read, 
-        Notifications.notification_trigger, 
-        Notifications.created_at, 
-        Notifications.updated_at, 
-        Notifications.notification_order,     
-        User.user_nickname AS trigger_nickname, 
-        User.user_email AS trigger_email, 
-        User.user_image AS trigger_image,
-        CASE
-          WHEN Notifications.notification_type IN ('${NotificationName.REPLY_TO_COMMENT}', '${NotificationName.COMMENT_ON_BOARD}') THEN Notifications.notification_location
-          ELSE NULL
-        END AS notification_comment,
-        Comment.parent_comment_id AS parent_comment_id,
-        CASE
-          WHEN Notifications.notification_type IN ('${NotificationName.FOLLOWING_NEW_BOARD}', '${NotificationName.BOARD_NEW_LIKE}') THEN Notifications.notification_location
-          WHEN Notifications.notification_type IN ('${NotificationName.REPLY_TO_COMMENT}', '${NotificationName.COMMENT_ON_BOARD}') THEN Comment.board_id
-          ELSE NULL
-        END AS notification_board,
-        Board.board_title AS board_title,
-        BoardUser.user_nickname AS board_writer,
-        Comment.comment_content AS comment_content 
-      FROM Notifications
-      JOIN User ON Notifications.notification_trigger = User.user_id
-      LEFT JOIN Comment ON Notifications.notification_location = Comment.comment_id
-      LEFT JOIN Board ON 
-         -- CASE 문에서 반환한 notification_board 값을 통해 Board와 조인
-          (CASE 
-              WHEN Notifications.notification_type IN ('${NotificationName.FOLLOWING_NEW_BOARD}', '${NotificationName.BOARD_NEW_LIKE}') THEN Notifications.notification_location
-              WHEN Notifications.notification_type IN ('${NotificationName.REPLY_TO_COMMENT}', '${NotificationName.COMMENT_ON_BOARD}') THEN Comment.board_id
-              ELSE NULL
-          END) = Board.board_id
-      LEFT JOIN User AS BoardUser ON Board.user_id = BoardUser.user_id 
-      WHERE Notifications.notification_recipient = ? 
-        ${sortQuery}
-        AND Notifications.deleted_at IS NULL
-    `;
-
-      const params: (string | number)[] = [listDto.userId];
-
-      let order = 'DESC';
-      // 커서가 있을 경우 커서 이후의 데이터를 가져오기 위해 조건 추가
-      if (listDto.cursor) {
-        const [{ notification_order: cursorOrder }] = await db.query(
-          `SELECT notification_order 
-         FROM Notifications 
-         WHERE notification_id = ? ${sortQuery};`,
-          [listDto.cursor]
-        );
-
-        if (!cursorOrder) throw new Error('유효하지 않은 커서입니다.');
-
-        query += ` AND notification_order ${listDto.isBefore ? '>' : '<'} ?`;
-        params.push(cursorOrder);
-
-        if (listDto.isBefore) order = 'ASC';
-      }
-
-      query += ` ORDER BY notification_order ${order} LIMIT ?`;
-      params.push(pageSize);
+      const { query, params } = await this._buildQuery(listDto, sortQuery);
       const result = await db.query(query, params);
+
       if (listDto.cursor && listDto.isBefore) result.reverse();
       return {
         result: true,
@@ -140,5 +78,84 @@ export class NotificationService {
       [userId]
     );
     return Number(countResult.totalCount.toString());
+  }
+  // 쿼리 및 파라미터 빌드
+  private static async _buildQuery(
+    listDto: NotificationListDto,
+    sortQuery: string
+  ) {
+    const pageSize = listDto.pageSize || 10;
+    const params: (string | number)[] = [listDto.userId];
+    let order = 'DESC';
+
+    let query = `
+      SELECT 
+        Notifications.notification_id, 
+        Notifications.notification_recipient, 
+        Notifications.notification_type, 
+        Notifications.notification_read, 
+        Notifications.notification_trigger, 
+        Notifications.created_at, 
+        Notifications.updated_at, 
+        Notifications.notification_order,     
+        User.user_nickname AS trigger_nickname, 
+        User.user_email AS trigger_email, 
+        User.user_image AS trigger_image,
+        CASE
+          WHEN Notifications.notification_type IN ('${NotificationName.REPLY_TO_COMMENT}', '${NotificationName.COMMENT_ON_BOARD}') THEN Notifications.notification_location
+          ELSE NULL
+        END AS notification_comment,
+        Comment.parent_comment_id AS parent_comment_id,
+        CASE
+          WHEN Notifications.notification_type IN ('${NotificationName.FOLLOWING_NEW_BOARD}', '${NotificationName.BOARD_NEW_LIKE}') THEN Notifications.notification_location
+          WHEN Notifications.notification_type IN ('${NotificationName.REPLY_TO_COMMENT}', '${NotificationName.COMMENT_ON_BOARD}') THEN Comment.board_id
+          ELSE NULL
+        END AS notification_board,
+        Board.board_title AS board_title,
+        BoardUser.user_nickname AS board_writer,
+        Comment.comment_content AS comment_content 
+      FROM Notifications
+      JOIN User ON Notifications.notification_trigger = User.user_id
+      LEFT JOIN Comment ON Notifications.notification_location = Comment.comment_id
+      LEFT JOIN Board ON 
+          (CASE 
+              WHEN Notifications.notification_type IN ('${NotificationName.FOLLOWING_NEW_BOARD}', '${NotificationName.BOARD_NEW_LIKE}') THEN Notifications.notification_location
+              WHEN Notifications.notification_type IN ('${NotificationName.REPLY_TO_COMMENT}', '${NotificationName.COMMENT_ON_BOARD}') THEN Comment.board_id
+              ELSE NULL
+          END) = Board.board_id
+      LEFT JOIN User AS BoardUser ON Board.user_id = BoardUser.user_id 
+      WHERE Notifications.notification_recipient = ? 
+        ${sortQuery}
+        AND Notifications.deleted_at IS NULL
+    `;
+
+    if (listDto.cursor) {
+      const cursorOrder = await this._getCursorOrder(listDto.cursor, sortQuery);
+      query += ` AND notification_order ${listDto.isBefore ? '>' : '<'} ?`;
+      params.push(cursorOrder);
+
+      if (listDto.isBefore) order = 'ASC';
+    }
+
+    query += ` ORDER BY notification_order ${order} LIMIT ?`;
+    params.push(pageSize);
+
+    return { query, params };
+  }
+
+  // 커서 정보 조회
+  private static async _getCursorOrder(
+    cursor: string,
+    sortQuery: string
+  ): Promise<number> {
+    const [{ notification_order: cursorOrder }] = await db.query(
+      `SELECT notification_order 
+       FROM Notifications 
+       WHERE notification_id = ? ${sortQuery};`,
+      [cursor]
+    );
+
+    if (!cursorOrder) throw new Error('유효하지 않은 커서입니다.');
+    return cursorOrder;
   }
 }

--- a/src/services/Notification/notification.ts
+++ b/src/services/Notification/notification.ts
@@ -44,6 +44,7 @@ export class NotificationService {
           WHEN Notifications.notification_type IN ('${NotificationName.REPLY_TO_COMMENT}', '${NotificationName.COMMENT_ON_BOARD}') THEN Notifications.notification_location
           ELSE NULL
         END AS notification_comment,
+        Comment.parent_comment_id AS parent_comment_id,
         CASE
           WHEN Notifications.notification_type IN ('${NotificationName.FOLLOWING_NEW_BOARD}', '${NotificationName.BOARD_NEW_LIKE}') THEN Notifications.notification_location
           WHEN Notifications.notification_type IN ('${NotificationName.REPLY_TO_COMMENT}', '${NotificationName.COMMENT_ON_BOARD}') THEN Comment.board_id
@@ -90,10 +91,8 @@ export class NotificationService {
 
       query += ` ORDER BY notification_order ${order} LIMIT ?`;
       params.push(pageSize);
-      console.log(query, params);
       const result = await db.query(query, params);
       if (listDto.cursor && listDto.isBefore) result.reverse();
-      console.log(result);
       return {
         result: true,
         data: result,

--- a/src/services/Notification/notification.ts
+++ b/src/services/Notification/notification.ts
@@ -7,6 +7,8 @@ import {
 } from '../../interfaces/notification';
 import { NotificationName } from '../../constants/notificationName';
 import { isNotificationNameType } from '../../utils/typegaurd/isNotificationNameType';
+import { CacheKeys } from '../../constants/cacheKeys';
+import { redis } from '../../loaders/redis';
 export class NotificationService {
   static async getAll(listDto: NotificationListDto): Promise<ListResponse> {
     try {
@@ -33,6 +35,28 @@ export class NotificationService {
       const error = ensureError(err);
       console.log(error.message);
       return { result: false, data: [], total: null, message: error.message };
+    }
+  }
+
+  static async getCached(userId: string): Promise<string[]> {
+    const key = CacheKeys.NOTIFICATION + userId;
+    const isExistCached = await redis.exists(key);
+
+    if (isExistCached) {
+      const cachedNotifications = await redis.lrange(key, 0, -1);
+      return cachedNotifications;
+    }
+
+    return [];
+  }
+
+  static deleteCashed(userId: string) {
+    try {
+      const key = CacheKeys.NOTIFICATION + userId;
+      redis.unlink(key);
+    } catch (err) {
+      const error = ensureError(err);
+      console.log(error.message);
     }
   }
 

--- a/src/services/Notification/saveNotifications.ts
+++ b/src/services/Notification/saveNotifications.ts
@@ -13,7 +13,7 @@ import { CacheKeys } from '../../constants/cacheKeys';
 import { NotificationName } from '../../constants/notificationName';
 import { NotificationNameType } from '../../types/notification';
 
-export class saveNotificationService {
+export class SaveNotificationService {
   private static async _sendNotification(
     notificationDto: NotificationDto
   ): Promise<BasicResponse> {

--- a/src/services/Notification/saveNotifications.ts
+++ b/src/services/Notification/saveNotifications.ts
@@ -80,11 +80,13 @@ export class saveNotificationService {
         ]
       );
 
-      const sent = await this._sendNotification(notificationDto);
-
-      return savedCount > 0 && sent.result
-        ? { result: true, message: '단일 사용자에게 알림 전송 성공' }
-        : { result: false, message: '단일 사용자에게 알림 전송 실패' };
+      if (savedCount > 0) {
+        const sent = await this._sendNotification(notificationDto);
+        return sent.result
+          ? { result: true, message: '단일 사용자에게 알림 전송 성공' }
+          : { result: false, message: '단일 사용자에게 알림 전송 실패' };
+      }
+      return { result: false, message: '단일 사용자에게 알림 저장 실패' };
     } catch (err) {
       const error = ensureError(err);
       console.log(error.message);
@@ -176,9 +178,11 @@ export class saveNotificationService {
       );
 
       if (retryResult.dbSaveFails.length || retryResult.notifyFails.length) {
+        console.log(`DB에 저장 실패한 알림 : ${retryResult.dbSaveFails}`);
+        console.log(`유저에게 전송 실패한 : ${retryResult.notifyFails}`);
         return {
           result: false,
-          message: `일부 유저 혹은 전체 유저에게 알림 전달 실패\n실패한 유저 id : ${retryResult}`
+          message: `일부 유저 혹은 전체 유저에게 알림 전달 실패`
         };
       }
 

--- a/src/services/board/board.ts
+++ b/src/services/board/board.ts
@@ -146,6 +146,10 @@ export class BoardService {
         currentUser.user_id
       ); // 추가될 시 1, 추가되지 않으면 0
 
+      if (board.user_id === userId && likedInRedis === 1) {
+        return { result: true, message: '자신의 게시물에 좋아요 추가 성공' };
+      }
+
       return likedInRedis === 1
         ? {
             result: true,

--- a/src/utils/sse/handleClientClose.ts
+++ b/src/utils/sse/handleClientClose.ts
@@ -1,0 +1,26 @@
+import { Response, Request } from 'express';
+import { clientsService } from '../notification/clients';
+import { ensureError } from '../../errors/ensureError';
+
+export function handleClientClose(
+  req: Request,
+  res: Response,
+  intervalId: NodeJS.Timeout
+): void {
+  try {
+    req.on('close', () => {
+      clearInterval(intervalId);
+      if (req.id) clientsService.delete(req.id);
+      console.log('[연결 close] 클라이언트 제거');
+    });
+
+    req.on('timeout', () => {
+      clearInterval(intervalId);
+      if (req.id) clientsService.delete(req.id);
+      console.log('[연결 timeout] 클라이언트 제거');
+    });
+  } catch (err) {
+    const error = ensureError(err);
+    throw new Error('[연결 종료 error] SSE 연결 종료 중 발생 : ', error);
+  }
+}

--- a/src/utils/sse/setSSEHeaders.ts
+++ b/src/utils/sse/setSSEHeaders.ts
@@ -1,0 +1,19 @@
+import { Response, Request } from 'express';
+import { ensureError } from '../../errors/ensureError';
+
+export function setSSEHeaders(res: Response): void {
+  try {
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+
+    if (res.flushHeaders) {
+      res.flushHeaders();
+    } else {
+      throw new Error('[flushHeader() 에러] SSE 헤더 설정 후 플러시 실패');
+    }
+  } catch (err) {
+    const error = ensureError(err);
+    throw new Error('[SSE 헤더 설정 에러] ', error);
+  }
+}

--- a/src/utils/typegaurd/isNotificationNameType.ts
+++ b/src/utils/typegaurd/isNotificationNameType.ts
@@ -1,0 +1,8 @@
+import { NotificationName } from '../../constants/notificationName';
+import { NotificationNameType } from '../../types/notification';
+
+export function isNotificationNameType(
+  value: any
+): value is NotificationNameType {
+  return Object.values(NotificationName).includes(value);
+}


### PR DESCRIPTION
## 🌎 PR 요약

알림 관련 기능의 리팩토링 및 최적화
- 알림 라우터 및 서비스 함수 로직을 분리하여 유지보수성 향상
- 자신의 게시물에 좋아요 추가 성공 시 알림이 발생하지 않도록 수정
- 대댓글 알림 데이터 수정

## 🔍 PR 유형

- [x] ✨ 새로운 기능 (Feature)
- [x] 🎨 코드 스타일 업데이트 (포맷팅, 로컬 변수 등)
- [x] ♻️ 리팩토링 (기능 변경 없음, API 변경 없음)

## 📝 작업 내용

- [x] 자신의 게시물에 좋아요 추가 성공 시 알림이 발생하지 않도록 수정
- [x] 데이터베이스에 성공적으로 저장된 경우에만 알림을 전송하도록 개선
- [x] 대댓글 알림 데이터 수정 및 반환되는 전체 알림 목록 데이터에 추가 속성 포함
- [x] 알림 라우터 및 서비스 함수 로직을 분리하여 유지보수성 향상
- [x] SSE 라우터에서 클라이언트 연결 종료 처리 및 헤더 설정 로직을 유틸 함수로 분리
- [x] 보편적인 클래스 명명 규칙에 맞지 않는 `saveNotificationService`를 `SaveNotificationService`로 변경

## 📍 참고 사항

## #️⃣ 연관된 이슈
