### PR TITLE
입력값 검증 로직 강화 및 알림 데이터 반환값 제한

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -34,7 +34,7 @@ app.use(cookieParser(process.env.COOKIE_SECRET));
 redisConnector;
 await dbConnector();
 
-loadAllSchedules(10, 10);
+loadAllSchedules();
 
 app.use(passport.initialize());
 await passportLoader();

--- a/src/constants/cashLimit.ts
+++ b/src/constants/cashLimit.ts
@@ -1,0 +1,2 @@
+export const TAG_CASH_LIMIT = 10;
+export const FOLLOWER_CASH_LIMIT = 100;

--- a/src/constants/cashedListSizeLimit.ts
+++ b/src/constants/cashedListSizeLimit.ts
@@ -1,0 +1,3 @@
+export const POPULAR_TAG_LIMIT = 10;
+
+export const TOP_FOLLOW_LIMIT = 10;

--- a/src/constants/pageSizeLimit.ts
+++ b/src/constants/pageSizeLimit.ts
@@ -1,0 +1,7 @@
+export const BOARD_PAGESIZE_LIMIT = 10;
+
+export const FOLLOW_PAGESIZE_LIMIT = 10;
+
+export const TOP_COMMENT_PAGESIZE_LIMIT = 10;
+
+export const NOTIFICATION_PAGESIZE_LIMIT = 10;

--- a/src/constants/validation.ts
+++ b/src/constants/validation.ts
@@ -1,0 +1,15 @@
+// 유저
+export const USER_NICKNAME_MAX = 30;
+export const USER_STATUS_MESSAGE_MAX = 60;
+
+// 게시글
+export const BOARD_TITLE_MAX = 100;
+
+// 태그
+export const TAG_NAME_MAX = 50;
+
+// 카테고리
+export const CATEGORY_NAME_MAX = 30;
+
+// 댓글
+export const COMMENT_CONTENT_MAX = 500;

--- a/src/loaders/scheduler.ts
+++ b/src/loaders/scheduler.ts
@@ -2,7 +2,7 @@ import schedule from 'node-schedule';
 import { createScheduleConfig } from '../config/schedule';
 import { JobScheduler } from '../services/scheduler/index';
 
-export const loadAllSchedules = (tagLimit?: number, followerLimit?: number) => {
+export const loadAllSchedules = () => {
   // 게시글 메트릭 업데이트 작업 (매일)
   schedule.scheduleJob(
     createScheduleConfig('daily', { hour: 0, minute: 0 }),
@@ -17,12 +17,12 @@ export const loadAllSchedules = (tagLimit?: number, followerLimit?: number) => {
 
   // 인기 태그 캐싱 작업 (매 시간마다)
   schedule.scheduleJob(createScheduleConfig('hourly', { hour: 1 }), () =>
-    JobScheduler.cachePopularTags(tagLimit)
+    JobScheduler.cachePopularTags()
   );
 
   // 최다 팔로워 보유 블로거 캐싱 작업 (매주)
   schedule.scheduleJob(
     createScheduleConfig('weekly', { dayOfWeek: 1, hour: 0, minute: 0 }),
-    () => JobScheduler.cacheTopFollowersWeekly(followerLimit)
+    () => JobScheduler.cacheTopFollowersWeekly()
   );
 };

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -13,6 +13,8 @@ import {
 import { LoginUserDto, LoginServiceDto, SignUpDto } from '../interfaces/auth';
 import { validate } from '../middleware/express-validation';
 import { body, header } from 'express-validator';
+import { USER_NICKNAME_MAX } from '../constants/validation';
+import { validateFieldByteLength } from '../utils/validation/validateFieldByteLength ';
 
 export const authRouter = Router();
 
@@ -163,7 +165,11 @@ authRouter.post(
       .if(body('provider').not().equals('google')) // 'provider'가 'google'이 아닌 경우에만 비밀번호 검증
       .isLength({ min: 8 })
       .matches(/(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*])/),
-    body('nickname').notEmpty(),
+    body('nickname')
+      .notEmpty()
+      .custom((nickname) =>
+        validateFieldByteLength('nickname', nickname, USER_NICKNAME_MAX)
+      ),
     body('provider').if(body('provider').exists()).isIn(['google']) // 'provider'가 존재하면 'google'인지 확인
   ]),
   async (req: Request, res: Response) => {

--- a/src/routes/board.ts
+++ b/src/routes/board.ts
@@ -23,7 +23,11 @@ import {
 } from '../interfaces/response';
 import { BoardCommentListService } from '../services/comment/boardCommentList';
 import { stripHtmlTags } from '../utils/string/stripHtmlTags';
-import { BOARD_TITLE_MAX, USER_NICKNAME_MAX } from '../constants/validation';
+import {
+  BOARD_TITLE_MAX,
+  TAG_NAME_MAX,
+  USER_NICKNAME_MAX
+} from '../constants/validation';
 import { validateFieldByteLength } from '../utils/validation/validateFieldByteLength ';
 
 export const boardRouter = Router();
@@ -39,7 +43,10 @@ boardRouter.get(
         'sort의 값이 존재한다면 like, view 중 하나의 값이어야합니다.'
       ),
     query('query').optional({ checkFalsy: true }).isString(),
-    query('tag').optional({ checkFalsy: true }).isString(),
+    query('tag')
+      .optional({ checkFalsy: true })
+      .isString()
+      .custom((value) => validateFieldByteLength('태그', value, TAG_NAME_MAX)),
     query('cursor')
       .optional({ checkFalsy: true })
       .matches(/^[0-9a-f]{32}$/i),
@@ -101,7 +108,10 @@ boardRouter.get(
       .withMessage(
         'sort의 값이 존재한다면 like, view 중 하나의 값이어야합니다.'
       ),
-    query('tag').optional({ checkFalsy: true }).isString(),
+    query('tag')
+      .optional({ checkFalsy: true })
+      .isString()
+      .custom((value) => validateFieldByteLength('태그', value, TAG_NAME_MAX)),
     query('cursor')
       .optional({ checkFalsy: true })
       .matches(/^[0-9a-f]{32}$/i),
@@ -281,14 +291,12 @@ boardRouter.post(
     body('tagNames')
       .optional({ checkFalsy: true })
       .custom((tags) => {
-        if (typeof tags === 'string') tags = [tags];
-
-        if (!Array.isArray(tags))
-          throw new Error('태그는 문자열 또는 배열 형태여야 합니다.');
-
-        if (tags.length > 10) {
+        tags = typeof tags === 'string' ? [tags] : tags;
+        if (tags.length > 10)
           throw new Error('태그는 최대 10개까지 허용됩니다.');
-        }
+
+        tags.forEach((tag: string) => validateFieldByteLength('태그', tag, 50));
+
         return true;
       }),
     body('categoryId')
@@ -376,14 +384,12 @@ boardRouter.put(
     body('tagNames')
       .optional({ checkFalsy: true })
       .custom((tags) => {
-        if (typeof tags === 'string') tags = [tags];
-
-        if (!Array.isArray(tags))
-          throw new Error('태그는 문자열 또는 배열 형태여야 합니다.');
-
-        if (tags.length > 10) {
+        tags = typeof tags === 'string' ? [tags] : tags;
+        if (tags.length > 10)
           throw new Error('태그는 최대 10개까지 허용됩니다.');
-        }
+
+        tags.forEach((tag: string) => validateFieldByteLength('태그', tag, 50));
+
         return true;
       }),
     body('categoryId')

--- a/src/routes/board.ts
+++ b/src/routes/board.ts
@@ -23,6 +23,8 @@ import {
 } from '../interfaces/response';
 import { BoardCommentListService } from '../services/comment/boardCommentList';
 import { stripHtmlTags } from '../utils/string/stripHtmlTags';
+import { BOARD_TITLE_MAX, USER_NICKNAME_MAX } from '../constants/validation';
+import { validateFieldByteLength } from '../utils/validation/validateFieldByteLength ';
 
 export const boardRouter = Router();
 
@@ -38,7 +40,9 @@ boardRouter.get(
       ),
     query('query').optional({ checkFalsy: true }).isString(),
     query('tag').optional({ checkFalsy: true }).isString(),
-    query('cursor').optional({ checkFalsy: true }).isString(),
+    query('cursor')
+      .optional({ checkFalsy: true })
+      .matches(/^[0-9a-f]{32}$/i),
     query('page-size')
       .optional({ checkFalsy: true })
       .toInt() // 숫자로 전환
@@ -87,7 +91,9 @@ boardRouter.get(
 boardRouter.get(
   '/list/:nickname',
   validate([
-    param('nickname').isString(),
+    param('nickname').custom((nickname) =>
+      validateFieldByteLength('nickname', nickname, USER_NICKNAME_MAX)
+    ),
     query('query').optional({ checkFalsy: true }).isString(),
     query('sort')
       .optional({ checkFalsy: true })
@@ -96,7 +102,9 @@ boardRouter.get(
         'sort의 값이 존재한다면 like, view 중 하나의 값이어야합니다.'
       ),
     query('tag').optional({ checkFalsy: true }).isString(),
-    query('cursor').optional({ checkFalsy: true }).isString(),
+    query('cursor')
+      .optional({ checkFalsy: true })
+      .matches(/^[0-9a-f]{32}$/i),
     query('page-size')
       .optional({ checkFalsy: true })
       .toInt() // 숫자로 전환
@@ -168,7 +176,9 @@ boardRouter.get(
       .optional({ checkFalsy: true })
       .isIn(['like', 'dislike'])
       .withMessage('sort의 값이 존재한다면 "like" 또는 "dislike"이어야합니다.'),
-    query('cursor').optional({ checkFalsy: true }).isString(),
+    query('cursor')
+      .optional({ checkFalsy: true })
+      .matches(/^[0-9a-f]{32}$/i),
     query('page-size')
       .optional({ checkFalsy: true })
       .toInt()
@@ -252,7 +262,9 @@ boardRouter.post(
     header('Authorization')
       .matches(/^Bearer\s[^\s]+$/)
       .withMessage('올바른 토큰 형식이 아닙니다.'),
-    body('title').notEmpty(),
+    body('title').custom((title) =>
+      validateFieldByteLength('title', title, BOARD_TITLE_MAX)
+    ),
     body('content')
       .notEmpty()
       .withMessage('내용을 입력해 주세요.')
@@ -345,7 +357,9 @@ boardRouter.put(
     body('boardId')
       .matches(/^[0-9a-f]{32}$/i)
       .withMessage('올바른 형식의 게시글 id가 아닙니다.'),
-    body('title').notEmpty(),
+    body('title').custom((title) =>
+      validateFieldByteLength('title', title, BOARD_TITLE_MAX)
+    ),
     body('content')
       .notEmpty()
       .withMessage('내용을 입력해 주세요.')

--- a/src/routes/board.ts
+++ b/src/routes/board.ts
@@ -22,6 +22,7 @@ import {
   UserListResponse
 } from '../interfaces/response';
 import { BoardCommentListService } from '../services/comment/boardCommentList';
+import { stripHtmlTags } from '../utils/string/stripHtmlTags';
 
 export const boardRouter = Router();
 
@@ -252,7 +253,18 @@ boardRouter.post(
       .matches(/^Bearer\s[^\s]+$/)
       .withMessage('올바른 토큰 형식이 아닙니다.'),
     body('title').notEmpty(),
-    body('content').notEmpty(),
+    body('content')
+      .notEmpty()
+      .withMessage('내용을 입력해 주세요.')
+      .custom((value) => {
+        const strippedContent = stripHtmlTags(value); // 유틸리티 함수 사용
+        if (strippedContent.length === 0) {
+          throw new Error(
+            '내용에 HTML 태그를 제외한 실제 텍스트가 있어야 합니다.'
+          );
+        }
+        return true;
+      }),
     body('public').isString(), // 폼 데이터의 필드는 텍스트로 전송
     body('tagNames')
       .optional({ checkFalsy: true })
@@ -334,7 +346,18 @@ boardRouter.put(
       .matches(/^[0-9a-f]{32}$/i)
       .withMessage('올바른 형식의 게시글 id가 아닙니다.'),
     body('title').notEmpty(),
-    body('content').notEmpty(),
+    body('content')
+      .notEmpty()
+      .withMessage('내용을 입력해 주세요.')
+      .custom((value) => {
+        const strippedContent = stripHtmlTags(value);
+        if (strippedContent.length === 0) {
+          throw new Error(
+            '내용에 HTML 태그를 제외한 실제 텍스트가 있어야 합니다.'
+          );
+        }
+        return true;
+      }),
     body('public').isString(),
     body('tagNames')
       .optional({ checkFalsy: true })

--- a/src/routes/category.ts
+++ b/src/routes/category.ts
@@ -11,6 +11,8 @@ import {
   UpdateCategoryNameDto
 } from '../interfaces/category';
 import { categoryService } from '../services/category';
+import { validateFieldByteLength } from '../utils/validation/validateFieldByteLength ';
+import { CATEGORY_NAME_MAX, USER_NICKNAME_MAX } from '../constants/validation';
 
 export const categoryRouter = Router();
 
@@ -22,7 +24,9 @@ categoryRouter.get(
       .optional({ checkFalsy: true })
       .matches(/^Bearer\s[^\s]+$/)
       .withMessage('토큰이 없습니다.'),
-    param('nickname').notEmpty(),
+    param('nickname').custom((nickname) =>
+      validateFieldByteLength('nickname', nickname, USER_NICKNAME_MAX)
+    ),
     query('topcategory-id')
       .optional({ checkFalsy: true })
       .matches(/^[0-9a-f]{32}$/i)
@@ -59,7 +63,9 @@ categoryRouter.post(
     header('Authorization')
       .matches(/^Bearer\s[^\s]+$/)
       .withMessage('토큰이 없습니다.'),
-    body('categoryName').notEmpty(),
+    body('categoryName').custom((categoryName) =>
+      validateFieldByteLength('categoryName', categoryName, CATEGORY_NAME_MAX)
+    ),
     body('topcategoryId')
       .optional({ checkFalsy: true })
       .matches(/^[0-9a-f]{32}$/i)
@@ -102,7 +108,9 @@ categoryRouter.put(
     body('categoryId')
       .matches(/^[0-9a-f]{32}$/i)
       .withMessage('올바른 카테고리 id 형식이 아닙니다.'),
-    body('categoryName').notEmpty().withMessage('categoryName은 필수입니다.')
+    body('categoryName').custom((categoryName) =>
+      validateFieldByteLength('categoryName', categoryName, CATEGORY_NAME_MAX)
+    )
   ]),
   jwtAuth,
   async (req: Request, res: Response) => {

--- a/src/routes/comment.ts
+++ b/src/routes/comment.ts
@@ -14,6 +14,8 @@ import {
 import { MultipleNotificationResponse } from '../interfaces/response';
 import { SaveNotificationService } from '../services/Notification/saveNotifications';
 import { CommentListService } from '../services/comment/commentList';
+import { validateFieldByteLength } from '../utils/validation/validateFieldByteLength ';
+import { COMMENT_CONTENT_MAX } from '../constants/validation';
 
 export const commentRouter = Router();
 
@@ -27,7 +29,13 @@ commentRouter.post(
     body('boardId')
       .matches(/^[0-9a-f]{32}$/i)
       .withMessage('유효한 게시글 ID 형식이 아닙니다.'),
-    body('commentContent').notEmpty().withMessage('댓글 내용은 필수입니다.'),
+    body('commentContent').custom((commentContent) =>
+      validateFieldByteLength(
+        'commentContent',
+        commentContent,
+        COMMENT_CONTENT_MAX
+      )
+    ),
     body('parentCommentId')
       .optional({ checkFalsy: true })
       .matches(/^[0-9a-f]{32}$/i)
@@ -121,7 +129,13 @@ commentRouter.put(
     body('commentId')
       .matches(/^[0-9a-f]{32}$/i)
       .withMessage('유효한 댓글 ID가 아닙니다.'),
-    body('commentContent').notEmpty().withMessage('댓글 내용은 필수입니다.')
+    body('commentContent').custom((commentContent) =>
+      validateFieldByteLength(
+        'commentContent',
+        commentContent,
+        COMMENT_CONTENT_MAX
+      )
+    )
   ]),
   jwtAuth,
   async (req: Request, res: Response) => {

--- a/src/routes/notifications.ts
+++ b/src/routes/notifications.ts
@@ -82,7 +82,9 @@ notificationsRouter.get(
       .withMessage(
         'pageSize의 값이 존재한다면 null이거나 0보다 큰 양수여야합니다.'
       ),
-    query('cursor').optional({ checkFalsy: true }).isString(),
+    query('cursor')
+      .optional({ checkFalsy: true })
+      .matches(/^[0-9a-f]{32}$/i),
     query('is-before')
       .optional({ checkFalsy: true })
       .custom((value) => {
@@ -136,7 +138,7 @@ notificationsRouter.delete(
       .optional({ checkFalsy: true })
       .matches(/^Bearer\s[^\s]+$/)
       .withMessage('올바른 토큰 형식이 아닙니다.'),
-    body('notificationId').isString()
+    body('notificationId').matches(/^[0-9a-f]{32}$/i)
   ]),
   jwtAuth,
   async (req: Request, res: Response) => {

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -21,6 +21,11 @@ import { LimitRequestDto } from '../interfaces/limitRequestDto';
 import { upload } from '../middleware/multer';
 import { jwtAuth } from '../middleware/passport-jwt-checker';
 import { SaveNotificationService } from '../services/Notification/saveNotifications';
+import { validateFieldByteLength } from '../utils/validation/validateFieldByteLength ';
+import {
+  USER_NICKNAME_MAX,
+  USER_STATUS_MESSAGE_MAX
+} from '../constants/validation';
 export const usersRouter = Router();
 
 // 특정 이메일/닉네임의 중복 여부 확인 (POST : /users/duplication)
@@ -302,7 +307,9 @@ usersRouter.get(
       .optional({ checkFalsy: true })
       .matches(/^Bearer\s[^\s]+$/)
       .withMessage('올바른 토큰 형식이 아닙니다.'),
-    param('nickname').notEmpty().withMessage('닉네임은 비어 있을 수 없습니다.')
+    param('nickname').custom((nickname) =>
+      validateFieldByteLength('nickname', nickname, USER_NICKNAME_MAX)
+    )
   ]),
   jwtAuth,
   async (req: Request, res: Response) => {
@@ -341,8 +348,9 @@ usersRouter.put(
       .withMessage('올바른 토큰 형식이 아닙니다.'),
     body('nickname')
       .optional({ checkFalsy: true })
-      .isString()
-      .withMessage('닉네임은 문자열이어야 합니다.'),
+      .custom((nickname) =>
+        validateFieldByteLength('nickname', nickname, USER_NICKNAME_MAX)
+      ),
     body('password')
       .optional({ checkFalsy: true })
       .isLength({ min: 8 })
@@ -350,8 +358,13 @@ usersRouter.put(
       .withMessage('비밀번호는 문자열이어야 합니다.'),
     body('statusMessage')
       .optional({ checkFalsy: true })
-      .isString()
-      .withMessage('상태 메시지는 문자열이어야 합니다.')
+      .custom((statusMessage) =>
+        validateFieldByteLength(
+          'statusMessage',
+          statusMessage,
+          USER_STATUS_MESSAGE_MAX
+        )
+      )
   ]),
   jwtAuth,
   async (req: Request, res: Response) => {

--- a/src/services/Notification/notification.ts
+++ b/src/services/Notification/notification.ts
@@ -135,9 +135,9 @@ export class NotificationService {
           WHEN Notifications.notification_type IN ('${NotificationName.REPLY_TO_COMMENT}', '${NotificationName.COMMENT_ON_BOARD}') THEN Comment.board_id
           ELSE NULL
         END AS notification_board,
-        Board.board_title AS board_title,
+        SUBSTRING(Board.board_title, 1, 30) AS board_title,
         BoardUser.user_nickname AS board_writer,
-        Comment.comment_content AS comment_content 
+        SUBSTRING(Comment.comment_content, 1, 30) AS comment_content
       FROM Notifications
       JOIN User ON Notifications.notification_trigger = User.user_id
       LEFT JOIN Comment ON Notifications.notification_location = Comment.comment_id

--- a/src/services/Notification/notification.ts
+++ b/src/services/Notification/notification.ts
@@ -9,13 +9,17 @@ import { NotificationName } from '../../constants/notificationName';
 import { isNotificationNameType } from '../../utils/typegaurd/isNotificationNameType';
 import { CacheKeys } from '../../constants/cacheKeys';
 import { redis } from '../../loaders/redis';
+import {
+  BOARD_PAGESIZE_LIMIT,
+  NOTIFICATION_PAGESIZE_LIMIT
+} from '../../constants/pageSizeLimit';
 export class NotificationService {
   static async getAll(listDto: NotificationListDto): Promise<ListResponse> {
     try {
       const sortQuery = this._buildSortQuery(listDto.sort);
 
       const totalCount = await this._getTotalCount(listDto.userId, sortQuery);
-      const pageSize = listDto.pageSize || 10;
+      const pageSize = listDto.pageSize || NOTIFICATION_PAGESIZE_LIMIT;
       const totalPageCount = Math.ceil(totalCount / pageSize);
 
       const { query, params } = await this._buildQuery(listDto, sortQuery);
@@ -108,7 +112,7 @@ export class NotificationService {
     listDto: NotificationListDto,
     sortQuery: string
   ) {
-    const pageSize = listDto.pageSize || 10;
+    const pageSize = listDto.pageSize || BOARD_PAGESIZE_LIMIT;
     const params: (string | number)[] = [listDto.userId];
     let order = 'DESC';
 

--- a/src/services/board/board.ts
+++ b/src/services/board/board.ts
@@ -164,7 +164,7 @@ export class BoardService {
               },
               location: {
                 boardId: boardId,
-                boardTitle: board.board_title
+                boardTitle: board.board_title.substring(0, 30)
               }
             },
             message: '좋아요 추가 성공'

--- a/src/services/board/boardList.ts
+++ b/src/services/board/boardList.ts
@@ -11,6 +11,7 @@ import { BoardInDBDto } from '../../interfaces/board/boardInDB';
 import { ListResponse, UserListResponse } from '../../interfaces/response';
 import { parseFieldToNumber } from '../../utils/parseFieldToNumber';
 import { CacheKeys } from '../../constants/cacheKeys';
+import { BOARD_PAGESIZE_LIMIT } from '../../constants/pageSizeLimit';
 
 export class BoardListService {
   static getList = async (listDto: ListDto): Promise<ListResponse> => {
@@ -27,7 +28,7 @@ export class BoardListService {
         params
       );
 
-      const pageSize = listDto.pageSize || 10;
+      const pageSize = listDto.pageSize || BOARD_PAGESIZE_LIMIT;
 
       const sortOptions: SortOptions = {
         pageSize: pageSize,
@@ -45,7 +46,7 @@ export class BoardListService {
 
       const totalCount = Number(countResult.totalCount.toString());
       const totalPageCount = Math.ceil(totalCount / pageSize);
-
+      console.log(query, params);
       return sortedList.length >= 0
         ? {
             result: true,
@@ -130,7 +131,7 @@ export class BoardListService {
         params
       );
 
-      const pageSize = listDto.pageSize || 10;
+      const pageSize = listDto.pageSize || BOARD_PAGESIZE_LIMIT;
 
       const sortOptions: SortOptions = {
         pageSize: pageSize,

--- a/src/services/board/saveBoard.ts
+++ b/src/services/board/saveBoard.ts
@@ -144,7 +144,7 @@ export class saveBoardService {
           },
           location: {
             boardId: boardId,
-            boardTitle: boardDto.title
+            boardTitle: boardDto.title.substring(0, 30)
           }
         },
         message: '게시글 저장 성공'

--- a/src/services/comment/boardCommentList.ts
+++ b/src/services/comment/boardCommentList.ts
@@ -3,6 +3,7 @@ import { ensureError } from '../../errors/ensureError';
 import { BoardCommentListDto } from '../../interfaces/board/listDto';
 import { redis } from '../../loaders/redis';
 import { CacheKeys } from '../../constants/cacheKeys';
+import { TOP_COMMENT_PAGESIZE_LIMIT } from '../../constants/pageSizeLimit';
 export class BoardCommentListService {
   // 특정 게시판의 최상위 댓글을 조회하고 사용자 정보와 함께 반환
   static getTopLevelCommentsByPostId = async (
@@ -57,7 +58,7 @@ export class BoardCommentListService {
       const [countResult] = await db.query(countQuery, [commentDto.boardId]);
       const totalCount = Number(countResult.totalCount);
 
-      const pageSize = commentDto.pageSize || 10; // 기본 페이지 크기 설정
+      const pageSize = commentDto.pageSize || TOP_COMMENT_PAGESIZE_LIMIT;
       const totalPageCount = Math.ceil(totalCount / pageSize);
 
       // Redis에서 좋아요/싫어요 수를 가져와 기존 데이터에 더함

--- a/src/services/comment/comment.ts
+++ b/src/services/comment/comment.ts
@@ -28,13 +28,8 @@ export class commentService {
           LIMIT 1;
         `;
 
-      const [
-        {
-          user_id: boardWriterId,
-          user_nickname: boardWriterNickname,
-          board_title: boardTitle
-        }
-      ] = await db.query(boardWriterQuery, [boardId]);
+      const [{ user_id: boardWriterId, user_nickname: boardWriterNickname }] =
+        await db.query(boardWriterQuery, [boardId]);
 
       if (!boardWriterId)
         return { result: false, message: '존재하지 않거나 삭제된 게시글' };
@@ -70,8 +65,18 @@ export class commentService {
             [commentDto.userId]
           );
 
-          const [{ comment_content: commentContent }] = await db.query(
-            `SELECT comment_content FROM Comment WHERE comment_id = ?`,
+          const [
+            {
+              comment_content: commentContent,
+              board_title: commentedBoardTitle
+            }
+          ] = await db.query(
+            `SELECT 
+              SUBSTRING(C.comment_content, 1, 30) as comment_content, 
+              SUBSTRING(B.board_title, 1, 30) as board_title
+            FROM Comment C
+            JOIN Board B ON C.board_id = B.board_id
+            WHERE C.comment_id = ?`,
             [commentId]
           );
 
@@ -88,7 +93,7 @@ export class commentService {
               boardId: boardId,
               parentCommentId: commentDto.parentCommentId,
               commentId: commentId,
-              boardTitle: boardTitle,
+              boardTitle: commentedBoardTitle,
               commentContent: commentContent,
               boardWriterNickname: boardWriterNickname
             }
@@ -109,8 +114,8 @@ export class commentService {
           { comment_content: commentContent, board_title: commentedBoardTitle }
         ] = await db.query(
           `SELECT 
-            C.comment_content, 
-            B.board_title 
+            SUBSTRING(C.comment_content, 1, 30) as comment_content, 
+            SUBSTRING(B.board_title, 1, 30) as board_title
           FROM Comment C
           JOIN Board B ON C.board_id = B.board_id
           WHERE C.comment_id = ?`,

--- a/src/services/scheduler/index.ts
+++ b/src/services/scheduler/index.ts
@@ -40,21 +40,20 @@ export class JobScheduler {
     }
   };
 
-  public static cachePopularTags = async (limit: number = 10) => {
+  public static cachePopularTags = async () => {
     const jobName = '인기 태그 캐싱';
     try {
-      const isSuccess = await TagCacheJobService.cacheTags(limit);
+      const isSuccess = await TagCacheJobService.cacheTags();
       this._logJobResult(jobName, isSuccess);
     } catch (err) {
       console.error(`[ERROR] ${jobName} 작업 중 에러 발생:`, err);
     }
   };
 
-  public static cacheTopFollowersWeekly = async (limit: number = 10) => {
+  public static cacheTopFollowersWeekly = async () => {
     const jobName = '최다 팔로워 보유 블로거 캐싱';
     try {
-      const isSuccess =
-        await TopFollowersCacheJobService.cacheTopFollowers(limit);
+      const isSuccess = await TopFollowersCacheJobService.cacheTopFollowers();
       this._logJobResult(jobName, isSuccess);
     } catch (err) {
       console.error(`[ERROR] ${jobName} 작업 중 에러 발생:`, err);

--- a/src/services/tag.ts
+++ b/src/services/tag.ts
@@ -2,15 +2,17 @@ import { ensureError } from '../errors/ensureError';
 import { LimitRequestDto } from '../interfaces/limitRequestDto';
 import { redis } from '../loaders/redis';
 import { CacheKeys } from '../constants/cacheKeys';
+import { POPULAR_TAG_LIMIT } from '../constants/cashedListSizeLimit';
 
 export class tagService {
   static getPopularList = async (tagDto: LimitRequestDto) => {
     try {
+      const tagLimit = tagDto.limit || POPULAR_TAG_LIMIT;
       // 태그 이름과 함께 점수를 반환
       const cashedTags = await redis.zrevrange(
         CacheKeys.POPULAR_TAGS,
         0,
-        tagDto.limit - 1,
+        tagLimit - 1,
         'WITHSCORES'
       );
 

--- a/src/services/user/follow.ts
+++ b/src/services/user/follow.ts
@@ -11,6 +11,8 @@ import {
   FollowingListUser
 } from '../../interfaces/user/follow';
 import { NotificationName } from '../../constants/notificationName';
+import { FOLLOW_PAGESIZE_LIMIT } from '../../constants/pageSizeLimit';
+import { TOP_FOLLOW_LIMIT } from '../../constants/cashedListSizeLimit';
 
 export class FollowService {
   static getFollowList = async (followListDto: FollowListDto) => {
@@ -37,7 +39,7 @@ export class FollowService {
 
       const thisUser = user.user_id;
       const currentUser = followListDto.userId;
-      const pageSize = followListDto.pageSize || 10;
+      const pageSize = followListDto.pageSize || FOLLOW_PAGESIZE_LIMIT;
       const offset = (followListDto.page - 1) * pageSize;
 
       const followingsList: FollowingListUser[] = await db.query(
@@ -121,10 +123,11 @@ export class FollowService {
   // 최다 팔로워 보유 블로거 리스트 조회
   static getTopFollowersList = async (topFollowersDto: LimitRequestDto) => {
     try {
+      const followerLimit = topFollowersDto.limit || TOP_FOLLOW_LIMIT;
       const cachedTopFollowers = await redis.zrevrange(
         CacheKeys.TOP_FOLLOWERS,
         0,
-        topFollowersDto.limit - 1,
+        followerLimit - 1,
         'WITHSCORES'
       );
 

--- a/src/utils/string/stripHtmlTags.ts
+++ b/src/utils/string/stripHtmlTags.ts
@@ -1,0 +1,3 @@
+export const stripHtmlTags = (value: string): string => {
+  return value.replace(/<\/?[^>]+(>|$)/g, '').trim();
+};

--- a/src/utils/validation/validateFieldByteLength .ts
+++ b/src/utils/validation/validateFieldByteLength .ts
@@ -1,0 +1,15 @@
+export function validateFieldByteLength(
+  fieldName: string,
+  value: string,
+  maxByteLength: number
+) {
+  // TextEncoder로 바이트 길이 계산
+  const byteLength = new TextEncoder().encode(value).length;
+
+  if (byteLength > maxByteLength) {
+    throw new Error(
+      `${fieldName}은(는) 최대 ${maxByteLength}바이트까지 허용됩니다.`
+    );
+  }
+  return true;
+}


### PR DESCRIPTION
## 🌎 PR 요약

이번 PR에서는 **입력값의 바이트 제한**을 추가하고 **상수**를 적용했습니다.

- 태그 인기 조회, 팔로워 수 조회 등에서 하드 코딩 된 제한 값을 **상수로 대체**하였습니다.  

- 댓글, 게시물, 태그 이름 등 다양한 필드에 **바이트 제한 로직**을 추가하여 입력 데이터의 유효성을 강화하였습니다.

- 게시글 저장/수정 시 내용이 비어있지 않으면 저장되도록 하였는데, HTML 태그만 존재하는 경우에도 저장되는 문제를 해결하기 위해 **HTML 태그 제거 후 내용을 검증하는 로직**을 추가했습니다.

- **알림 데이터에서 게시글의 제목 / 내용 반환 시 전체 데이터를 반환하지 않고 30글자만 반환**하도록 수정하였습니다.

## 🔍 PR 유형

- [x] ✨ 새로운 기능 (Feature)
- [x] 🎨 코드 스타일 업데이트 (포맷팅, 로컬 변수 등)
- [x] ♻️ 리팩토링 (기능 변경 없음, API 변경 없음)

## 📝 작업 내용

- **상수 적용**
  - [x] 인기 태그 조회 시 상수를 사용하여 limit 기본값을 상수로 대체 (`POPULAR_TAG_LIMIT` 적용)
  - [x] 팔로워 조회 시 상수를 사용하여 limit 기본값을 상수로 대체 (`TOP_FOLLOW_LIMIT` 적용)
  - [x] 페이지 크기 상수 적용 (`pageSizeLimit.ts`에 정의된 상수를 사용하여 하드코딩된 페이지 기본값 수정)
  - [x] Redis 캐시 조회 시 상수를 사용하여 한도 설정 (`TAG_CASH_LIMIT`, `FOLLOWER_CASH_LIMIT` 적용)

- **바이트 제한 로직**
  - [x] 불필요한 파라미터 제거 및 코드 구조 정리
  - [x] `constants/validation.ts`에 정의된 상수값을 이용하여 유저 닉네임, 상태 메세지 입력값에 대한 바이트 제한 추가
  - [x] 게시글 제목 100바이트 제한, 태그 이름과 카테고리 이름 30바이트 제한, 댓글 내용 500바이트 제한 추가
  - [x] 필드값 제한 확인을 위한 유틸리티 함수 추가

- **알림 데이터 수정**
  - [x] 알림 데이터에서 게시글의 제목 및 내용을 반환할 때 30글자만 반환하도록 수정

- **HTML 태그 제거 및 검증**
  - [x] 게시글 저장/수정 시 HTML 태그를 제거한 후 내용을 검증하는 로직 추가

## 📍 참고 사항

## #️⃣ 연관된 이슈

