### PR TITLE
인기 팔로워 리스트의 캐싱 대상 변경

### DIFF
--- a/src/interfaces/user/follow.ts
+++ b/src/interfaces/user/follow.ts
@@ -20,3 +20,10 @@ export interface FollowListDto {
   pageSize: number;
   page: number;
 }
+
+export interface topFollowerInfo {
+  user_id: string;
+  user_nickname: string;
+  user_image: string;
+  deleted_at: string;
+}

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -154,11 +154,11 @@ usersRouter.get(
   jwtAuth,
   async (req: Request, res: Response) => {
     try {
-      const topFollowersDto: LimitRequestDto = {
+      const limitRequestDto: LimitRequestDto = {
         limit: req.query.limit as unknown as number
       };
       const result: BasicResponse =
-        await FollowService.getTopFollowersList(topFollowersDto);
+        await FollowService.getTopFollowersList(limitRequestDto);
 
       if (result.result === true) {
         return res.status(200).send(result);

--- a/src/services/user/follow.ts
+++ b/src/services/user/follow.ts
@@ -1,7 +1,7 @@
 import { db } from '../../loaders/mariadb';
 import { ensureError } from '../../errors/ensureError';
 import { UserInfoDto } from '../../interfaces/user/userInfo';
-import { FollowListDto } from '../../interfaces/user/follow';
+import { FollowListDto, topFollowerInfo } from '../../interfaces/user/follow';
 import { SingleNotificationResponse } from '../../interfaces/response';
 import { redis } from '../../loaders/redis';
 import { LimitRequestDto } from '../../interfaces/limitRequestDto';
@@ -138,14 +138,27 @@ export class FollowService {
           message: '최다 팔로워 보유 블로거 조회 실패'
         };
       }
+      const topFollowersWithScores: any = [];
+      const userIds = cachedTopFollowers.filter((_, index) => index % 2 === 0);
+      const userInfos = await db.query(
+        `
+          SELECT user_id,user_nickname, user_image, deleted_at
+          FROM User
+          WHERE user_id IN (?)
+        `,
+        [userIds]
+      );
 
-      const topFollowersWithScores = [];
-      for (let i = 0; i < cachedTopFollowers.length; i += 2) {
-        topFollowersWithScores.push({
-          userName: cachedTopFollowers[i],
-          score: Number(cachedTopFollowers[i + 1])
-        });
-      }
+      userInfos.forEach((userInfo: topFollowerInfo) => {
+        const index = cachedTopFollowers.indexOf(userInfo.user_id);
+        if (userInfo.deleted_at === null) {
+          topFollowersWithScores.push({
+            userName: userInfo.user_nickname,
+            userImage: userInfo.user_image,
+            score: Number(cachedTopFollowers[index + 1])
+          });
+        }
+      });
 
       return {
         result: true,

--- a/src/services/user/follow.ts
+++ b/src/services/user/follow.ts
@@ -121,9 +121,9 @@ export class FollowService {
   };
 
   // 최다 팔로워 보유 블로거 리스트 조회
-  static getTopFollowersList = async (topFollowersDto: LimitRequestDto) => {
+  static getTopFollowersList = async (limitRequestDto: LimitRequestDto) => {
     try {
-      const followerLimit = topFollowersDto.limit || TOP_FOLLOW_LIMIT;
+      const followerLimit = limitRequestDto.limit || TOP_FOLLOW_LIMIT;
       const cachedTopFollowers = await redis.zrevrange(
         CacheKeys.TOP_FOLLOWERS,
         0,


### PR DESCRIPTION
## 🌎 PR 요약

이번 PR에서 인기 팔로워 리스트의 캐싱 대상을 닉네임에서 아이디로 변경하여 닉네임 수정 시 캐싱된 데이터의 불일치 문제를 해결하였습니다. 

## 🔍 PR 유형

- [x] 🐛 버그 수정 (Bugfix)
- [x] ✨ 새로운 기능 (Feature)
- [x] 🎨 코드 스타일 업데이트 (포맷팅, 로컬 변수 등)
- [x] ♻️ 리팩토링 (기능 변경 없음, API 변경 없음)

## 📝 작업 내용

- [x] **인기 팔로워 리스트의 캐싱 대상을 닉네임에서 아이디로 변경**
- [x] topFollowerInfo 인터페이스 추가
- [x] 최다 팔로워 리스트 조회 시 캐싱된 데이터에서 유저 정보를 추가 조회하도록 수정
- [x] 최다 팔로워 조회 함수의 파라미터 네이밍 변경 (topFollowersDto → limitRequestDto)

## 📍 참고 사항

## #️⃣ 연관된 이슈
