### PR TITLE
카테고리 구조를 3계층에서 2계층으로 단순화 및 이동 제한 기능 수정

### DIFF
--- a/src/interfaces/category.ts
+++ b/src/interfaces/category.ts
@@ -1,6 +1,6 @@
-export interface CategoryDto {
+export interface CategoryIdDto {
   userId: string;
-  categoryId?: string;
+  categoryId: string;
 }
 
 export interface CategoryListDto {
@@ -17,12 +17,12 @@ export interface HierarchicalCategoryDto {
   board_count: number;
 }
 
-export interface UpdateCategoryNameDto extends CategoryDto {
+export interface UpdateCategoryNameDto extends CategoryIdDto {
   categoryName: string;
 }
 
-export interface UpdateCategoryLevelDto extends CategoryDto {
-  topcategoryId: string;
+export interface UpdateCategoryLevelDto extends CategoryIdDto {
+  newTopCategoryId: string;
 }
 
 export interface NewCategoryDto {

--- a/src/routes/category.ts
+++ b/src/routes/category.ts
@@ -62,9 +62,12 @@ categoryRouter.post(
     header('Authorization')
       .matches(/^Bearer\s[^\s]+$/)
       .withMessage('토큰이 없습니다.'),
-    body('categoryName').custom((categoryName) =>
-      validateFieldByteLength('categoryName', categoryName, CATEGORY_NAME_MAX)
-    ),
+    body('categoryName')
+      .trim()
+      .notEmpty()
+      .custom((categoryName) =>
+        validateFieldByteLength('categoryName', categoryName, CATEGORY_NAME_MAX)
+      ),
     body('topcategoryId')
       .optional({ checkFalsy: true })
       .matches(/^[0-9a-f]{32}$/i)
@@ -105,9 +108,12 @@ categoryRouter.put(
     body('categoryId')
       .matches(/^[0-9a-f]{32}$/i)
       .withMessage('올바른 카테고리 id 형식이 아닙니다.'),
-    body('categoryName').custom((categoryName) =>
-      validateFieldByteLength('categoryName', categoryName, CATEGORY_NAME_MAX)
-    )
+    body('categoryName')
+      .trim()
+      .notEmpty()
+      .custom((categoryName) =>
+        validateFieldByteLength('categoryName', categoryName, CATEGORY_NAME_MAX)
+      )
   ]),
   jwtAuth,
   async (req: Request, res: Response) => {

--- a/src/routes/category.ts
+++ b/src/routes/category.ts
@@ -3,7 +3,7 @@ import { validate } from '../middleware/express-validation';
 import { header, body, query, param } from 'express-validator';
 import { jwtAuth } from '../middleware/passport-jwt-checker';
 import {
-  CategoryDto,
+  CategoryIdDto,
   CategoryListDto,
   NewCategoryDto,
   UpdateCategoryLevelDto,
@@ -170,7 +170,7 @@ categoryRouter.put(
       const categoryDto: UpdateCategoryLevelDto = {
         userId: req.id,
         categoryId: req.body.categoryId,
-        topcategoryId: req.body.topcategoryId
+        newTopCategoryId: req.body.topcategoryId
       };
 
       const result = await categoryService.modifyLevel(categoryDto);
@@ -204,7 +204,7 @@ categoryRouter.delete(
         );
       }
 
-      const categoryDto: CategoryDto = {
+      const categoryDto: CategoryIdDto = {
         userId: req.id,
         categoryId: req.body.categoryId
       };

--- a/src/services/category.ts
+++ b/src/services/category.ts
@@ -296,13 +296,22 @@ export class categoryService {
     }
 
     const { affectedRows: deletedCount } = await db.query(
-      `UPDATE Board_Category SET deleted_at = CURRENT_TIMESTAMP WHERE category_id = ? AND user_id= ? AND deleted_at IS NULL`,
-      [categoryDto.categoryId, categoryDto.userId]
+      `UPDATE Board_Category AS C
+        LEFT JOIN Board AS B ON B.category_id = C.category_id 
+        SET B.deleted_at = CURRENT_TIMESTAMP, C.deleted_at = CURRENT_TIMESTAMP, C.topcategory_id = NULL
+        WHERE C.category_id = ? 
+          AND C.deleted_at IS NULL 
+          AND B.deleted_at IS NULL;`,
+      [categoryDto.categoryId]
     );
 
     if (deletedCount === 0) {
       throw new InternalServerError('카테고리 삭제 실패');
     }
-    return { result: true, message: '카테고리 삭제 성공' };
+
+    return {
+      result: true,
+      message: '카테고리 및 카테고리에 속한 게시글 삭제 성공'
+    };
   };
 }

--- a/src/services/category.ts
+++ b/src/services/category.ts
@@ -280,33 +280,20 @@ export class categoryService {
     userId: string
   ) => {
     try {
-      // 상위 카테고리가 존재하는지 확인
-      const [topcategory] = await db.query(
-        `SELECT 1 FROM Board_Category 
-          WHERE category_id = ? 
-          AND user_id = ? 
-          AND deleted_at IS NULL;`,
-        [topcategoryId, userId]
-      );
-
-      if (!topcategory)
-        throw new InternalServerError(
-          '상위 카테고리로 지정한 카테고리가 존재하지 않습니다'
-        );
-
       // 상위 카테고리가 이미 다른 상위 카테고리를 가지고 있는지 확인
       const [topCategoryCheck] = await db.query(
         `SELECT 1 FROM Board_Category 
           WHERE category_id = ? 
           AND user_id = ? 
           AND topcategory_id IS NOT NULL 
+          AND topcategory_id != '' 
           AND deleted_at IS NULL;`,
         [topcategoryId, userId]
       );
 
       if (topCategoryCheck)
         throw new BadRequestError(
-          '이미 상위 카테고리를 가진 카테고리는 다른 카테고리의 상위 카테고리가 될 수 없습니다.'
+          '상위 카테고리로 지정한 카테고리가 존재하지 않거나, 이미 상위 카테고리를 갖고 있습니다.'
         );
 
       return true;

--- a/src/services/category.ts
+++ b/src/services/category.ts
@@ -226,7 +226,7 @@ export class categoryService {
     await this._checkDuplicatedCategoryName(
       userId,
       currentCategory.category_name,
-      categoryId
+      newTopCategoryId
     );
 
     const { affectedRows: modifiedCount } = await db.query(

--- a/src/services/category.ts
+++ b/src/services/category.ts
@@ -1,7 +1,7 @@
 import { db } from '../loaders/mariadb';
 import { ensureError } from '../errors/ensureError';
 import {
-  CategoryDto,
+  CategoryIdDto,
   CategoryListDto,
   HierarchicalCategoryDto,
   NewCategoryDto,
@@ -277,7 +277,7 @@ export class categoryService {
     };
   };
 
-  static delete = async (categoryDto: CategoryDto) => {
+  static delete = async (categoryDto: CategoryIdDto) => {
     // 삭제하려는 카테고리를 상위 카테고리로 가지는지 확인
     const [subcategories] = await db.query(
       `SELECT COUNT(*) AS subcategoryCount FROM Board_Category WHERE topcategory_id = ? AND user_id= ? AND deleted_at IS NULL`,

--- a/src/services/category.ts
+++ b/src/services/category.ts
@@ -212,13 +212,19 @@ export class categoryService {
     const { userId, categoryId, newTopCategoryId } = categoryDto;
 
     const [currentCategory] = await db.query(
-      `SELECT category_name FROM Board_Category 
+      `SELECT category_name, topcategory_id FROM Board_Category 
        WHERE category_id = ?`,
       [categoryId]
     );
 
     if (!currentCategory) {
       throw new InternalServerError('수정 대상 카테고리를 찾을 수 없습니다.');
+    }
+
+    if (!currentCategory.topcategory_id && newTopCategoryId) {
+      throw new BadRequestError(
+        '최상위 카테고리를 다른 레벨로 이동시킬 수 없습니다. '
+      );
     }
 
     await this._checkTopCategoryValidity(newTopCategoryId, userId);

--- a/src/services/category.ts
+++ b/src/services/category.ts
@@ -20,9 +20,13 @@ export class categoryService {
       [categoryDto.nickname]
     );
 
-    //if (!user) {
-    // throw new NotFoundError('해당 닉네임을 가진 유저가 존재하지 않습니다.');
-    //}
+    if (!user) {
+      return {
+        result: false,
+        message: '해당 닉네임을 가진 유저가 존재하지 않습니다.'
+      };
+      //  throw new NotFoundError('해당 닉네임을 가진 유저가 존재하지 않습니다.');
+    }
 
     // 카테고리 ID가 없는 게시글의 개수 조회
     const [uncategorizedCountResult] = await db.query(

--- a/src/services/category.ts
+++ b/src/services/category.ts
@@ -233,7 +233,7 @@ export class categoryService {
 
     const [currentCategory] = await db.query(
       `SELECT category_name FROM Board_Category 
-       WHERE categoryId = ?`,
+       WHERE category_id = ?`,
       [categoryId]
     );
 


### PR DESCRIPTION
## 🌎 PR 요약

이번 PR에서는 카테고리 구조를 3계층에서 2계층으로 단순화하고, 동일한 계층 내에서만 카테고리 이동이 가능하도록 제한하였습니다. 이를 통해 카테고리 관리의 일관성을 높이고, 복잡성을 줄였습니다.

## 🔍 PR 유형

- 🐛 버그 수정 (Bugfix)
- ♻️ 리팩토링 (기능 변경 없음, API 변경 없음)

## 📝 작업 내용

- [x] 카테고리 구조를 3계층에서 2계층으로 단순화
- [x] 동일한 계층 내에서만 카테고리 이동이 가능하도록 수정
- [x] 상위 및 하위 카테고리 이름 중복 검사 로직 개선 (동일한 계층 내에서 동일한 이름이 중복되지 않도록 수정)

## 📍 참고 사항

## #️⃣ 연관된 이슈


