### PR TITLE
임시 저장된 게시글 기능 개선 및 페이징 기능 추가

### DIFF
--- a/src/constants/pageSizeLimit.ts
+++ b/src/constants/pageSizeLimit.ts
@@ -5,3 +5,5 @@ export const FOLLOW_PAGESIZE_LIMIT = 10;
 export const TOP_COMMENT_PAGESIZE_LIMIT = 10;
 
 export const NOTIFICATION_PAGESIZE_LIMIT = 10;
+
+export const DRAFT_PAGESIZE_LIMIT = 10;

--- a/src/interfaces/draft.ts
+++ b/src/interfaces/draft.ts
@@ -23,6 +23,7 @@ export interface DraftIdDto {
 export interface DraftListDto {
   userId: string;
   cursor?: string;
+  page?: number;
   pageSize?: number;
   isBefore?: boolean;
 }

--- a/src/routes/draft.ts
+++ b/src/routes/draft.ts
@@ -264,6 +264,34 @@ draftRouter.get(
   }
 );
 
+// 임시 저장된 게시글 확인 (GET: /draft/:draftId/user-check)
+draftRouter.get(
+  '/:draftId/user-check',
+  validate([
+    header('Authorization')
+      .matches(/^Bearer\s[^\s]+$/)
+      .withMessage('올바른 토큰 형식이 아닙니다.'),
+    param('draftId')
+      .matches(/^:[0-9a-f]{24}$/i)
+      .withMessage('올바른 형식의 임시 저장 게시글 id는 24글자의 문자열입니다.')
+  ]),
+  jwtAuth,
+  checkWriter(true),
+  async (req: Request, res: Response) => {
+    try {
+      if (!req.isWriter)
+        throw new ForbiddenError('해당 유저가 임시 저장한 게시글이 아닙니다.');
+
+      return res.status(200).send({
+        result: true,
+        message: '해당 유저가 임시 저장한 게시글입니다.'
+      });
+    } catch (err) {
+      handleError(err, res);
+    }
+  }
+);
+
 // 임시 저장된 게시글 삭제 (DELETE: /draft/:draftId)
 draftRouter.delete(
   '/',

--- a/src/routes/draft.ts
+++ b/src/routes/draft.ts
@@ -35,6 +35,13 @@ draftRouter.get(
         }
         return true;
       }),
+    query('page')
+      .optional({ checkFalsy: true })
+      .toInt()
+      .isInt({ min: 1 })
+      .withMessage(
+        'pageSize의 값이 존재한다면 null이거나 0보다 큰 양수여야합니다.'
+      ),
     query('page-size')
       .optional({ checkFalsy: true })
       .toInt()
@@ -65,6 +72,9 @@ draftRouter.get(
       const draftListDto: DraftListDto = {
         userId: req.id,
         cursor: (req.query.cursor as string) || undefined,
+        page: req.query.page
+          ? parseInt(req.query.page as string, 10)
+          : undefined,
         pageSize: req.query['page-size']
           ? parseInt(req.query['page-size'] as string, 10)
           : undefined,

--- a/src/routes/draft.ts
+++ b/src/routes/draft.ts
@@ -266,13 +266,13 @@ draftRouter.get(
 
 // 임시 저장된 게시글 삭제 (DELETE: /draft/:draftId)
 draftRouter.delete(
-  '/:draftId',
+  '/',
   validate([
     header('Authorization')
       .matches(/^Bearer\s[^\s]+$/)
       .withMessage('올바른 토큰 형식이 아닙니다.'),
-    param('draftId')
-      .matches(/^:[0-9a-f]{24}$/i)
+    body('draftId')
+      .matches(/^[0-9a-f]{24}$/i)
       .withMessage('올바른 형식의 임시 저장 게시글 id는 24글자의 문자열입니다.')
   ]),
   jwtAuth,
@@ -284,10 +284,9 @@ draftRouter.delete(
 
       const draftIdDto: DraftIdDto = {
         userId: req.id as string,
-        draftId: req.params.draftId.split(':')[1]
+        draftId: req.body.draftId
       };
 
-      console.log('draftIdDto', draftIdDto);
       const result = await DraftService.deleteDraft(draftIdDto);
 
       return res.status(result.result ? 200 : 500).send(result);

--- a/src/services/draft.ts
+++ b/src/services/draft.ts
@@ -64,13 +64,20 @@ export class DraftService {
         ? { updatedAt: 1, _id: -1 }
         : { updatedAt: -1, _id: 1 };
 
+    const page = draftListDto.page ?? 1;
+
     let draftList = await draftCollection
       .find(query)
       .sort(sortQuery)
-      .limit(pageSize)
+      .limit(pageSize * page)
       .toArray();
 
-    if (cursor && isBefore == true) draftList = draftList.reverse();
+    const listLength = draftList.length % pageSize || pageSize;
+
+    draftList =
+      cursor && isBefore
+        ? draftList.reverse().slice(0, listLength)
+        : draftList.slice(-listLength);
 
     if (!draftList || draftList.length === 0) {
       return {

--- a/src/services/draft.ts
+++ b/src/services/draft.ts
@@ -73,7 +73,15 @@ export class DraftService {
     if (cursor && isBefore == true) draftList = draftList.reverse();
 
     if (!draftList || draftList.length === 0) {
-      throw new NotFoundError('저장된 게시글 목록이 없습니다.');
+      return {
+        result: true,
+        data: {
+          list: null,
+          totalCount: 0,
+          totalPages: 0
+        },
+        message: '저장된 게시글 목록이 없습니다.'
+      };
     }
 
     return {

--- a/src/services/draft.ts
+++ b/src/services/draft.ts
@@ -15,13 +15,14 @@ import { NotFoundError } from '../errors/notFoundError';
 import { replaceImageUrlsWithS3Links } from '../utils/string/replaceImageUrlsWithS3Links';
 import { BadRequestError } from '../errors/badRequestError';
 import { db } from '../loaders/mariadb';
+import { DRAFT_PAGESIZE_LIMIT } from '../constants/pageSizeLimit';
 
 export class DraftService {
   static getDraftList = async (draftListDto: DraftListDto) => {
     const draftCollection = mongodb.db('board_db').collection('drafts');
 
     const { userId, cursor, isBefore } = draftListDto;
-    const pageSize = draftListDto.pageSize ?? 100;
+    const pageSize = draftListDto.pageSize ?? DRAFT_PAGESIZE_LIMIT;
 
     // 기본 검색 조건: 유저 ID
     const query: Filter<DraftFilterDto> = { userId };

--- a/src/services/draft.ts
+++ b/src/services/draft.ts
@@ -179,23 +179,11 @@ export class DraftService {
   private static _validateDraftFields(
     draftData: DraftDto | UpdateDraftDto
   ): void {
-    const {
-      title,
-      content,
-      public: isPublic,
-      categoryId,
-      tagNames
-    } = draftData;
+    const { title, content } = draftData;
 
-    if (
-      !title ||
-      !content ||
-      isPublic === undefined ||
-      !categoryId ||
-      !tagNames
-    ) {
+    if (!title && !content) {
       throw new BadRequestError(
-        '저장할 내용이 없습니다. 최소 하나의 필드를 입력해주세요.'
+        '저장할 제목/내용이 없습니다. 최소 하나의 필드를 입력해주세요.'
       );
     }
   }


### PR DESCRIPTION
## 🌎 PR 요약

이번 PR에서는 임시 저장된 게시글 기능을 개선하고, 페이징 기능에 관련된 수정 및 기능 추가를 진행했습니다. 또한, 게시글 소유자 확인과 관련된 API 추가 작업도 포함되었습니다.

## 🔍 PR 유형

- 🐛 버그 수정 (Bugfix)
- ✨ 새로운 기능 (Feature)

## 📝 작업 내용

- [x] Draft 페이지 사이즈 기본값 상수로 분리하여 관리
- [x] 제목 또는 내용이 없는 경우 임시저장 불가하도록 수정
- [x] 임시 저장된 게시글 리스트 조회 시, 게시글 데이터가 없을 경우 NotFound 에러가 아닌 빈 리스트 반환
- [x] 임시 저장된 게시글 삭제 시 draftId를 param가 아닌 body로 전달하도록 수정
- [x] 임시 저장된 게시글 소유자 확인 API 추가
- [x] 페이징 기능에서 페이지 건너뛰기 기능 추가

## 📍 참고 사항

- **임시 저장된 게시글 리스트 조회 시, 게시글 데이터가 없을 경우 NotFound 에러가 아닌 빈 리스트 반환**
  NotFound 에러를 반환하는 대신 빈 리스트를 반환하는 것은, 데이터가 없는 것이 에러 상황이 아니기 때문에 사용자가 데이터를 요청했을 때, 단순히 결과가 없음을 의미하도록 처리하기 위함입니다.

- **임시 저장된 게시글 삭제 시 draftId를 param가 아닌 body로 전달하도록 수정**
  RESTful API 디자인 원칙에 따라, 리소스를 수정 또는 삭제하는 경우 관련 데이터를 URL 파라미터가 아닌 요청 본문(body)에 포함시키는 것이 더 적절합니다. 이를 통해 데이터의 가독성을 높이고, 삭제 시 전달해야 할 데이터가 더욱 명확해집니다.

- **페이징 기능에서 페이지 건너뛰기 기능 추가**
  사용자가 특정 페이지로 건너뛰어 바로 조회할 수 있는 기능을 제공하여 UX를 개선하기 위함입니다. 기존에는 연속적인 페이징만 가능했지만, 이번 추가를 통해 사용자가 원하는 페이지로 즉시 이동할 수 있습니다.

## #️⃣ 연관된 이슈
#28 ( [63fa37b](https://github.com/MiffyAndKitty/BlogProject_Back/pull/27/commits/63fa37b4072d6dbf9f927419bf30c8befe68c478) )
