### PR TITLE
임시저장 게시글 개수 및 페이지 수 계산 로직 위치 수정

### DIFF
--- a/src/services/draft.ts
+++ b/src/services/draft.ts
@@ -41,6 +41,10 @@ export class DraftService {
         );
     }
 
+    // 전체 글 개수 계산
+    const totalCount = await draftCollection.countDocuments(query);
+    const totalPages = Math.ceil(totalCount / pageSize);
+
     if (cursorBoard) {
       query.$or = [
         {
@@ -54,10 +58,6 @@ export class DraftService {
         }
       ];
     }
-
-    // 전체 글 개수 계산
-    const totalCount = await draftCollection.countDocuments(query);
-    const totalPages = Math.ceil(totalCount / pageSize);
 
     const sortQuery: Filter<DraftSortQueryDto> =
       cursor && isBefore == true


### PR DESCRIPTION
## 🌎 PR 요약

이번 PR에서는 전체 글 개수 계산에서 발생한 문제를 수정하였으며, 페이지 수를 올바르게 계산하도록 `totalCount`와 `totalPages`의 로직 위치를 수정하였습니다.

## 🔍 PR 유형

- [x] 🐛 버그 수정 (Bugfix)

## 📝 작업 내용

- [x] 전체 글 개수와 페이지 수를 계산하는 로직을 더 적절한 위치로 이동하여 전체 글 개수 계산 문제 수정

## 📍 참고 사항

## #️⃣ 연관된 이슈

