### PR TITLE
페이지 건너뛰기 기능 추가

### DIFF
--- a/src/interfaces/board/listDto.ts
+++ b/src/interfaces/board/listDto.ts
@@ -1,4 +1,5 @@
 export interface SortOptions {
+  page?: number;
   pageSize: number;
   cursor?: string;
   isBefore?: boolean;

--- a/src/interfaces/notification.ts
+++ b/src/interfaces/notification.ts
@@ -28,10 +28,10 @@ export interface UserNotificationDto {
 export interface NotificationListDto {
   userId: string;
   page?: number;
-  pageSize: number;
-  cursor: string;
-  isBefore: boolean;
-  sort: string;
+  pageSize?: number;
+  cursor?: string;
+  isBefore?: boolean;
+  sort?: string;
 }
 
 export interface RetryFailedUsersResult {

--- a/src/interfaces/notification.ts
+++ b/src/interfaces/notification.ts
@@ -27,6 +27,7 @@ export interface UserNotificationDto {
 
 export interface NotificationListDto {
   userId: string;
+  page?: number;
   pageSize: number;
   cursor: string;
   isBefore: boolean;

--- a/src/routes/board.ts
+++ b/src/routes/board.ts
@@ -51,6 +51,13 @@ boardRouter.get(
     query('cursor')
       .optional({ checkFalsy: true })
       .matches(/^[0-9a-f]{32}$/i),
+    query('page')
+      .optional({ checkFalsy: true })
+      .toInt() // 숫자로 전환
+      .isInt({ min: 1 })
+      .withMessage(
+        'pageSize의 값이 존재한다면 null이거나 0보다 큰 양수여야합니다.'
+      ),
     query('page-size')
       .optional({ checkFalsy: true })
       .toInt() // 숫자로 전환
@@ -76,6 +83,7 @@ boardRouter.get(
         sort: req.query.sort as string,
         tag: req.query.tag as string,
         cursor: req.query.cursor as string,
+        page: req.query.page as unknown as number,
         pageSize: req.query['page-size'] as unknown as number,
         isBefore: req.query['is-before'] === 'true' ? true : false
       };
@@ -114,6 +122,13 @@ boardRouter.get(
     query('cursor')
       .optional({ checkFalsy: true })
       .matches(/^[0-9a-f]{32}$/i),
+    query('page')
+      .optional({ checkFalsy: true })
+      .toInt() // 숫자로 전환
+      .isInt({ min: 1 })
+      .withMessage(
+        'pageSize의 값이 존재한다면 null이거나 0보다 큰 양수여야합니다.'
+      ),
     query('page-size')
       .optional({ checkFalsy: true })
       .toInt() // 숫자로 전환
@@ -146,6 +161,7 @@ boardRouter.get(
         sort: req.query.sort as string,
         tag: req.query.tag as string,
         cursor: req.query.cursor as string,
+        page: req.query.page as unknown as number,
         pageSize: req.query['page-size'] as unknown as number,
         nickname: req.params.nickname.split(':')[1],
         userId: req.id,

--- a/src/routes/notifications.ts
+++ b/src/routes/notifications.ts
@@ -73,6 +73,13 @@ notificationsRouter.get(
       .optional({ checkFalsy: true })
       .matches(/^Bearer\s[^\s]+$/)
       .withMessage('올바른 토큰 형식이 아닙니다.'),
+    query('page')
+      .optional({ checkFalsy: true })
+      .toInt()
+      .isInt({ min: 1 })
+      .withMessage(
+        'page의 값이 존재한다면 null이거나 0보다 큰 양수여야합니다.'
+      ),
     query('page-size')
       .optional({ checkFalsy: true })
       .toInt()
@@ -112,6 +119,7 @@ notificationsRouter.get(
 
       const listDto: NotificationListDto = {
         userId: req.id,
+        page: req.query.page ? Number(req.query.page) : undefined,
         pageSize: req.query['page-size'] as unknown as number,
         cursor: req.query.cursor as string,
         isBefore: req.query['is-before'] === 'true' ? true : false,

--- a/src/routes/notifications.ts
+++ b/src/routes/notifications.ts
@@ -120,10 +120,12 @@ notificationsRouter.get(
       const listDto: NotificationListDto = {
         userId: req.id,
         page: req.query.page ? Number(req.query.page) : undefined,
-        pageSize: req.query['page-size'] as unknown as number,
-        cursor: req.query.cursor as string,
+        pageSize: req.query['page-size']
+          ? Number(req.query['page-size'])
+          : undefined,
+        cursor: req.query.cursor ? String(req.query.cursor) : undefined,
         isBefore: req.query['is-before'] === 'true' ? true : false,
-        sort: req.query.sort as string
+        sort: req.query.sort ? String(req.query.sort) : undefined
       };
 
       const result = await NotificationService.getAll(listDto);

--- a/src/services/Notification/notification.ts
+++ b/src/services/Notification/notification.ts
@@ -71,7 +71,7 @@ export class NotificationService {
   }
 
   // 정렬 쿼리 빌드
-  private static _buildSortQuery(sort: string): string {
+  private static _buildSortQuery(sort?: string): string {
     return isNotificationNameType(sort)
       ? `AND notification_type = '${sort}'`
       : '';

--- a/src/services/Notification/notification.ts
+++ b/src/services/Notification/notification.ts
@@ -210,7 +210,10 @@ export class NotificationService {
     const startIndex = isBefore ? -pageSize * page : pageSize * (page - 1);
     const endIndex = isBefore ? -pageSize * (page - 1) : pageSize * page;
 
-    result = result.slice(startIndex, endIndex);
+    result =
+      isBefore && startIndex - endIndex < pageSize
+        ? result.slice(0, pageSize)
+        : result.slice(startIndex, endIndex);
 
     return result;
   }

--- a/src/services/Notification/notification.ts
+++ b/src/services/Notification/notification.ts
@@ -29,26 +29,13 @@ export class NotificationService {
 
     if (listDto.cursor && listDto.isBefore) result.reverse();
 
-    if (
-      listDto.cursor &&
-      listDto.page &&
-      listDto.page > 1 &&
-      listDto.isBefore
-    ) {
-      // 커서가 있고 페이지가 있으며, 앞 페이지를 조회해야한다면
-      const startIndex = -pageSize * listDto.page;
-      const endIndex = -pageSize * (listDto.page - 1);
-      result = result.slice(startIndex, endIndex);
-    } else if (
-      listDto.cursor &&
-      listDto.page &&
-      listDto.page > 1 &&
-      !listDto.isBefore
-    ) {
-      // 커서가 있고 페이지가 있으며, 뒤 페이지를 조회해야한다면
-      const startIndex = pageSize * (listDto.page - 1);
-      const endIndex = pageSize * listDto.page;
-      result = result.slice(startIndex, endIndex);
+    if (listDto.cursor && listDto.page && listDto.page > 1) {
+      result = this._processPagination(
+        result,
+        listDto.page,
+        pageSize,
+        listDto.isBefore
+      );
     }
 
     return {
@@ -212,5 +199,19 @@ export class NotificationService {
     } catch (err) {
       throw ensureError(err, '커서 정보 조회 중 에러 발생');
     }
+  }
+
+  private static _processPagination(
+    result: any[],
+    page: number,
+    pageSize: number,
+    isBefore?: boolean
+  ): any[] {
+    const startIndex = isBefore ? -pageSize * page : pageSize * (page - 1);
+    const endIndex = isBefore ? -pageSize * (page - 1) : pageSize * page;
+
+    result = result.slice(startIndex, endIndex);
+
+    return result;
   }
 }

--- a/src/services/board/boardList.ts
+++ b/src/services/board/boardList.ts
@@ -301,12 +301,16 @@ export class BoardListService {
         const start = Math.max(0, cursorIndex - options.pageSize * page);
         const end = cursorIndex - options.pageSize * (page - 1);
 
-        return start - end >= 0
-          ? []
-          : data.slice(
-              Math.max(0, cursorIndex - options.pageSize * page),
-              cursorIndex - options.pageSize * (page - 1)
-            );
+        if (start - end >= 0) return [];
+
+        if (cursorIndex - options.pageSize * (page - 1) < options.pageSize) {
+          return data.slice(0, options.pageSize);
+        }
+
+        return data.slice(
+          Math.max(0, cursorIndex - options.pageSize * page),
+          cursorIndex - options.pageSize * (page - 1)
+        );
       }
       const isLast =
         cursorIndex + 1 + options.pageSize * (page - 1) >= data.length;
@@ -373,12 +377,12 @@ export class BoardListService {
 
       if (data.length <= (page - 1) * options.pageSize) return [];
 
-      const listLength = data.length % options.pageSize || options.pageSize;
-
-      data =
-        options.cursor && options.isBefore
-          ? data.reverse().slice(0, listLength).reverse()
-          : data.slice(-listLength);
+      if (options.cursor && options.isBefore) {
+        data = data.reverse().slice(0, options.pageSize).reverse();
+      } else {
+        const listLength = data.length % options.pageSize || options.pageSize;
+        data = data.slice(-listLength);
+      }
 
       if (options.cursor && options.isBefore === true) data = data.reverse();
 


### PR DESCRIPTION
## 🌎 PR 요약

이번 PR에서는 게시글 리스트 조회 시 페이지 건너뛰기 기능을 구현하였습니다.

## 🔍 PR 유형

- ✨ 새로운 기능 (Feature)


## 📝 작업 내용

- [x] `SortOptions` 인터페이스에 `page` 필드를 추가하여 DTO 확장
- [x] 게시글 리스트 조회 라우터에 페이지 파라미터를 추가
- [x] 페이지와 페이지 크기 필드에 대한 유효성 검사 로직 추가 (숫자로 변환하고 최소값 1 이상으로 제한)
- [x] 서비스 함수에 페이지 건너뛰기 기능 추가

## 📍 참고 사항

- 페이지 조회 시, 조회된 값이 `pageSize`보다 적을 경우 남은 페이지를 채워 `pageSize`만큼 반환하도록 수정 ([c481d9c](https://github.com/MiffyAndKitty/BlogProject_Back/pull/30/commits/c481d9c5810e67a3e5de1f452ffa37eb0ef3d4f7))

## #️⃣ 연관된 이슈
