### PR TITLE
jwt 토큰 설정 리팩토링 및 account, draft, users 라우터의 API Swagger 문서 추가

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -2,7 +2,7 @@ import '../config/env';
 import swaggerJsdoc from 'swagger-jsdoc';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { loadAndCombineYamlFiles } from '../utils/loadYamlFiles'; // 추가된 부분
+import { loadAndCombineYamlFiles } from '../utils/loadYamlFiles';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -26,6 +26,15 @@ export const swaggerDefinition = {
       url: process.env.ORIGIN_URL
     }
   ],
+  components: {
+    securitySchemes: {
+      bearerAuth: {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT'
+      }
+    }
+  },
   paths: combinedPaths
 };
 

--- a/src/swagger/account.yaml
+++ b/src/swagger/account.yaml
@@ -1,0 +1,247 @@
+paths:
+  /api/account/email-validation:
+    post:
+      summary: 이메일 유효성 확인을 위한 메일 전송
+      description: |
+        로컬 회원가입 시, 이메일 유효성 확인을 위한 메일을 사용자에게 전송합니다.
+        프론트와 사용자에게 동일한 여섯자리의 숫자를 반환합니다.
+      tags:
+        - 계정
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: user@example.com
+              required:
+                - email
+      responses:
+        '200':
+          description: 성공적으로 이메일 유효성 확인 이메일 전송 ( 메일함 확인 해주세요! )
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: true
+                  data:
+                    type: number
+                    example: 123456
+                  message:
+                    type: string
+                    example: '이메일 유효성 확인 이메일이 전송되었습니다.'
+        '400':
+          description: 올바른 이메일 형식이 아닌 경우
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: '데이터 유효성 검증 실패: 유효한 이메일을 입력하세요.'
+        '500':
+          description: 서버 내부 오류 (이메일 전송 중 에러가 발생한 경우)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: '에러 메세지'
+
+  /api/account/temp-password:
+    post:
+      summary: 임시 비밀번호 이메일 전송
+      description: 비밀번호 재설정을 위해 사용자에게 임시 비밀번호를 이메일로 전송합니다. 단, 구글 로그인 사용자에게는 불가능합니다.
+      tags:
+        - 계정
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: user@example.com
+              required:
+                - email
+      responses:
+        '200':
+          description: 성공적으로 임시 비밀번호 메일 전송 ( 메일함 확인 해주세요! )
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: '비밀번호 재설정 메일 전송 성공'
+        '400':
+          description: 올바른 이메일 형식이 아닌 경우
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: '데이터 유효성 검증 실패: 유효한 이메일을 입력하세요.'
+        '404':
+          description: 존재하지 않는 유저이거나 이미 탈퇴한 유저일 경우
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: '존재하지 않는 로컬 회원가입 유저, 혹은 이미 탈퇴한 유저입니다.'
+        '500':
+          description: 서버 내부 오류
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: '비밀번호 재설정 메일 전송 실패'
+  /api/account:
+    delete:
+      summary: 로컬 사용자 계정 탈퇴
+      description: 데이터베이스에서 사용자의 계정을 삭제 상태로 변경합니다.
+      tags:
+        - 계정
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 회원 탈퇴 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 회원 탈퇴가 성공적으로 처리되었습니다.
+        '404':
+          description: 존재하지 않는 회원 / 이미 탈퇴한 회원
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 존재하지 않는 회원입니다. / 이미 탈퇴된 회원입니다.
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 회원 탈퇴에 실패했습니다. (혹은 오류 메세지)
+  /api/account/google:
+    delete:
+      summary: 구글 계정 연동 해제
+      description: 구글과 연동된 계정을 해제합니다.
+      tags:
+        - 계정
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 구글 계정 연동 해제 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 구글 계정 연동 해제가 성공적으로 처리되었습니다.
+        '403':
+          description: 권한이 없거나 인증 토큰이 유효하지 않은 경우
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 인증 토큰이 유효하지 않습니다. 다시 로그인 해주세요.
+        '404':
+          description: 존재하지 않는 구글 계정 연동
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 구글 계정 연동이 존재하지 않습니다.
+        '500':
+          description: 서버 오류
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 구글 계정 연동 해제 중 오류가 발생했습니다.

--- a/src/swagger/draft.yaml
+++ b/src/swagger/draft.yaml
@@ -1,0 +1,645 @@
+paths:
+  /api/draft:
+    post:
+      tags:
+        - 임시 저장
+      security:
+        - bearerAuth: []
+      summary: 게시글 임시 저장
+      description: 게시글을 임시 저장합니다. 최소 하나의 필드만 존재하면 저장 가능합니다.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                  description: 게시글 제목
+                  example: '임시 저장 제목'
+                content:
+                  type: string
+                  description: 게시글 내용
+                  example: '임시 저장된 게시글의 내용'
+                public:
+                  type: string
+                  description: 공개 여부 (true 또는 false)
+                  example: 'true'
+                tagNames:
+                  type: array
+                  items:
+                    type: string
+                  description: 게시글 태그
+                  example: ['tag1', 'tag2']
+                categoryId:
+                  type: string
+                  description: 카테고리 ID (32자 문자열)
+                  example: '1234567890abcdef1234567890abcdef'
+                uploaded_files:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+                  description: 업로드된 파일들
+      responses:
+        200:
+          description: 임시 저장 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: true
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: '임시 저장에 성공하였습니다.'
+        400:
+          description: 최소 하나 이상의 필드를 채우지 않은 경우 / 올바른 형식의 필드 값을 입력하지 않은 경우
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: false
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: '저장할 내용이 없습니다. 최소 하나의 필드를 입력해주세요. / 데이터 유효성 검증 실패 메세지'
+        401:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: false
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: '로그인된 유저만 게시글 임시 저장이 가능합니다'
+        500:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: false
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: '서버 오류 메세지'
+    put:
+      tags:
+        - 임시 저장
+      security:
+        - bearerAuth: []
+      summary: 임시 저장된 게시글 수정
+      description: 게시글 임시 저장된 데이터를 수정합니다.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                draftId:
+                  type: string
+                  description: 임시 저장된 게시글 ID (24자 문자열)
+                  example: '60c72b2f9b1d8a001cf9d7b1'
+                title:
+                  type: string
+                  description: 게시글 제목
+                  example: '임시 저장 제목 수정'
+                content:
+                  type: string
+                  description: 게시글 내용
+                  example: '임시 저장된 게시글 내용 수정'
+                public:
+                  type: string
+                  description: 공개 여부 (true 또는 false)
+                  example: 'false'
+                tagNames:
+                  type: array
+                  items:
+                    type: string
+                  description: 게시글 태그
+                  example: ['tag1', 'tag2', 'tag3']
+                categoryId:
+                  type: string
+                  description: 카테고리 ID (32자 문자열)
+                  example: '1234567890abcdef1234567890abcdef'
+                uploaded_files:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+                  description: 업로드된 파일들
+      responses:
+        200:
+          description: 임시 저장 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: true
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: '임시 저장에 성공하였습니다.'
+        400:
+          description: 최소 하나 이상의 필드를 채우지 않은 경우 / 올바른 형식의 필드 값을 입력하지 않은 경우
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: false
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: '저장할 내용이 없습니다. 최소 하나의 필드를 입력해주세요. / 데이터 유효성 검증 실패 메세지'
+        401:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: false
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: '로그인된 유저만 게시글 임시 저장이 가능합니다'
+        500:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: false
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: '서버 오류 메세지'
+    delete:
+      tags:
+        - 임시 저장
+      security:
+        - bearerAuth: []
+      summary: 임시 저장된 게시글 삭제
+      description: 임시 저장된 게시글을 영구 삭제합니다.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                draftId:
+                  type: string
+                  example: 60c72b2f9b1d8a001cf9d7b1
+              required:
+                - draftId
+      responses:
+        200:
+          description: 임시 저장된 게시글 삭제 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: true
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: '임시 저장된 게시글이 삭제되었습니다.'
+        400:
+          description: 올바른 형식의 필드 값을 입력하지 않은 경우
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: false
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: 데이터 유효성 검증 실패 메세지
+        403:
+          description: 해당 유저가 임시 저장한 게시글의 id가 아닌 경우
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: false
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: 해당 유저가 임시 저장한 게시글이 아닙니다.
+        404:
+          description: 현재 로그인 한 유저가 작성한 게시글이 아니거나 존재하는 임시 저장 게시글 ID가 아닌 경우
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: false
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: '임시 저장된 게시글을 찾을 수 없습니다.'
+        500:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: false
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: '서버 오류 메세지'
+  /api/draft/:{draftId}:
+    get:
+      tags:
+        - 임시 저장
+      security:
+        - bearerAuth: []
+      summary: 게시글 임시 저장 조회
+      description: 임시 저장된 게시글을 조회합니다.
+      parameters:
+        - in: path
+          name: draftId
+          required: true
+          schema:
+            type: string
+            example: '60c72b2f9b1d8a001cf9d7b1'
+          description: 조회할 임시 저장 게시글 ID
+      responses:
+        200:
+          description: 게시글 조회 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      _id:
+                        type: string
+                        description: 게시글 ID
+                        example: '60c72b2f9b1d8a001cf9d7b1'
+                      title:
+                        type: string
+                        description: 게시글 제목
+                        example: '임시 저장된 게시글 제목'
+                      content:
+                        type: string
+                        description: 게시글 내용
+                        example: '임시 저장된 게시글 내용'
+                      public:
+                        type: boolean
+                        description: 공개 여부
+                        example: true
+                      tagNames:
+                        type: array
+                        items:
+                          type: string
+                        description: 게시글 태그 목록
+                        example: ['tag1', 'tag2']
+                      categoryId:
+                        type: string
+                        description: 카테고리 ID
+                        example: '1234567890abcdef1234567890abcdef'
+                      updatedAt:
+                        type: string
+                        format: date-time
+                        description: 게시글 수정 날짜
+                        example: '2024-09-17T03:31:59.000Z'
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: '임시 저장된 게시글 반환에 성공하였습니다.'
+        403:
+          description: 해당 유저가 임시 저장한 게시글의 id가 아닌 경우
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: false
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: 해당 유저가 임시 저장한 게시글이 아닙니다.
+        400:
+          description: 올바른 형식의 필드 값을 입력하지 않은 경우
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: false
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: 데이터 유효성 검증 실패 메세지
+        404:
+          description: 현재 로그인 한 유저가 작성한 게시글이 아니거나 존재하는 임시 저장 게시글 ID가 아닌 경우
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: false
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: '현재 로그인한 유저가 작성한 해당 id의 임시 저장된 게시글을 찾지 못하였습니다.'
+        500:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: false
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: '서버 오류 메세지'
+  /api/draft/:{draftId}/user-check:
+    get:
+      tags:
+        - 임시 저장
+      security:
+        - bearerAuth: []
+      summary: 임시 저장된 게시글 작성자 확인
+      description: 해당 임시 저장된 게시글이 현재 로그인한 유저의 게시글인지 확인합니다.
+      parameters:
+        - in: path
+          name: draftId
+          required: true
+          schema:
+            type: string
+            example: '60c72b2f9b1d8a001cf9d7b1'
+          description: 확인할 임시 저장된 게시글 ID
+      responses:
+        200:
+          description: 해당 유저가 작성한 임시 저장된 게시글입니다.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: true
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: '해당 유저가 임시 저장한 게시글입니다.'
+        400:
+          description: 잘못된 형식의 필드 값이 입력된 경우
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: false
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: '올바른 형식의 임시 저장 게시글 id는 24글자의 문자열입니다.'
+        403:
+          description: 해당 유저가 임시 저장한 게시글이 아닙니다.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: false
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: '해당 유저가 임시 저장한 게시글이 아닙니다.'
+        500:
+          description: 서버 오류 발생
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: false
+                  message:
+                    type: string
+                    description: 서버 오류 메시지
+                    example: '서버 오류 메세지'
+  /api/draft/list:
+    get:
+      tags:
+        - 임시 저장
+      security:
+        - bearerAuth: []
+      summary: 임시 저장된 게시글 목록 조회
+      description: 최신순으로 임시 저장된 게시글 목록을 조회합니다.
+      parameters:
+        - in: query
+          name: cursor
+          required: false
+          schema:
+            type: string
+          description: 페이징을 위한 커서 ID
+        - in: query
+          name: page-size
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+          description: 페이지당 가져올 게시글 수, 설정하지 않으면 기본값으로 10이 설정됩니다.
+        - in: query
+          name: is-before
+          required: false
+          schema:
+            type: boolean
+          description: true일 경우 커서 이전의 데이터를, false일 경우 커서 이후의 데이터를 가져옵니다. 기본값은 false입니다.
+        - in: query
+          name: page
+          required: false
+          schema:
+            type: number
+          description: 기본값은 1입니다. 넘겨볼 페이지의 수를 의미합니다.
+      responses:
+        200:
+          description: 임시 저장된 게시글 목록 반환 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      list:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            _id:
+                              type: string
+                              description: 게시글 ID
+                              example: '60c72b2f9b1d8a001cf9d7b1'
+                            title:
+                              type: string
+                              description: 게시글 제목
+                              example: '임시 저장된 게시글 제목'
+                            content:
+                              type: string
+                              description: 게시글 내용
+                              example: '임시 저장된 게시글 내용'
+                            public:
+                              type: boolean
+                              description: 공개 여부
+                              example: true
+                            tagNames:
+                              type: array
+                              items:
+                                type: string
+                              description: 게시글 태그 목록
+                              example: ['tag1', 'tag2']
+                            categoryId:
+                              type: string
+                              description: 카테고리 ID
+                              example: '1234567890abcdef1234567890abcdef'
+                            updatedAt:
+                              type: string
+                              format: date-time
+                              description: 게시글 수정 날짜
+                              example: '2024-09-17T03:31:59.000Z'
+                      totalCount:
+                        type: integer
+                        description: 전체 게시글 수
+                        example: 1
+                      totalPages:
+                        type: integer
+                        description: 전체 페이지 수
+                        example: 1
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: '임시 저장된 게시글 목록을 반환 성공했습니다.'
+        400:
+          description: 올바른 형식의 필드 값을 입력하지 않은 경우 ( 토큰 형식이 유효하지 않은 경우 )
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: false
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: 데이터 유효성 검증 실패 메세지
+        404:
+          description: 저장된 게시글 목록이 없습니다.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: false
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: '저장된 게시글 목록이 없습니다.'
+        500:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 성공 여부
+                    example: false
+                  message:
+                    type: string
+                    description: 결과 메시지
+                    example: '서버 오류 메세지'

--- a/src/swagger/users.yaml
+++ b/src/swagger/users.yaml
@@ -1,0 +1,112 @@
+paths:
+  /api/users/top-followers:
+    get:
+      tags:
+        - 사용자
+      summary: 지난 주 최다 팔로워 보유 블로거 목록 조회
+      description: |
+        지난 주 동안 가장 많은 팔로워를 보유한 블로거의 목록과 그들의 팔로워 수를 조회합니다.  
+        만약 블로거의 수가 지정한 limit에 미치지 못할 경우, 추가 태그가 0점으로 채워집니다.
+      parameters:
+        - name: limit
+          in: query
+          description: 가져올 블로거 수 (최소 1 이상의 정수)
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 10
+      responses:
+        '200':
+          description: 최다 팔로워 보유 블로거 조회 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    description: 요청 성공 여부
+                    example: true
+                  data:
+                    type: array
+                    description: 최다 팔로워 보유 블로거 목록
+                    items:
+                      type: object
+                      properties:
+                        userName:
+                          type: string
+                          description: 블로거의 닉네임
+                          example: 유저1
+                        userImage:
+                          type: string
+                          description: 블로거의 프로필 사진 URL
+                          example: 이미지 URL
+                        score:
+                          type: integer
+                          description: 해당 블로거의 팔로워 수
+                          example: 5
+                  message:
+                    type: string
+                    description: 응답 메시지
+                    example: '최다 팔로워 보유 블로거 조회 성공'
+              example:
+                result: true
+                data:
+                  - userName: '유저1'
+                    userImage: 'https://aws-s3-bucket-connected-vultr-mkblog.s3.ap-northeast-2.amazonaws.com/user-profile-image/40A1863665_0_480-removebg-preview.png_1723603898570'
+                    score: 3
+                  - userName: '유저2'
+                    userImage: null
+                    score: 2
+                  - userName: '유저3'
+                    userImage: null
+                    score: 1
+                  - userName: '유저4'
+                    userImage: null
+                    score: 1
+                  - userName: '대체 유저1'
+                    userImage: null
+                    score: 0
+                  - userName: '대체 유저2'
+                    userImage: null
+                    score: 0
+                  - userName: '대체 유저3'
+                    userImage: null
+                    score: 0
+                  - userName: '대체 유저4'
+                    userImage: null
+                    score: 0
+                  - userName: '대체 유저5'
+                    userImage: null
+                    score: 0
+                  - userName: '대체 유저6'
+                    userImage: null
+                    score: 0
+                message: '최다 팔로워 보유 블로거 조회 성공'
+        '400':
+          description: 잘못된 limit 파라미터로 인해 요청이 실패했을 때의 응답
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'limit 값은 1 이상의 양수여야 합니다.'
+        '500':
+          description: 서버 내부 오류
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: '최다 팔로워 보유 블로거 조회 실패'


### PR DESCRIPTION
## 🌎 PR 요약

이번 PR에서는 account, draft, users 라우터에 대한 API Swagger 문서를 추가하고, Swagger 설정 파일에 jwt 토큰 설정을 리팩토링하여 보안 관련 설정을 추가했습니다.

## 🔍 PR 유형

- ♻️ 리팩토링 (기능 변경 없음, API 변경 없음)
- 📝 문서 내용 변경

## 📝 작업 내용

- [x] Swagger 설정 파일에 JWT 토큰 설정 추가 (리팩토링)
- [x] account, draft, users 라우터에 대한 API Swagger 문서 작성 및 추가
## 📍 참고 사항

## #️⃣ 연관된 이슈
